### PR TITLE
fix: Update static file settings for improved clarity and structure

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -194,11 +194,13 @@ INTERNAL_IPS = [
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.1/howto/static-files/
-STATIC_URL = "static/"
-STATICFILES_DIRS = (os.path.join(BASE_DIR, "static"),)
-STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
+STATIC_URL = "/static/"
+STATICFILES_DIRS = [
+    BASE_DIR / "static",
+]
+STATIC_ROOT = BASE_DIR / "staticfiles"
 
-# Storage backend
+# Storage backend configuration for both default and staticfiles storage
 STORAGES = {
     "default": {
         "BACKEND": "django.core.files.storage.FileSystemStorage",


### PR DESCRIPTION
This pull request updates the static files configuration in `config/settings.py` to use path objects instead of string paths, and improves clarity and consistency for static file handling. The changes also update the `STATIC_URL` format and clarify the storage backend configuration.

**Static files configuration improvements:**

* Changed `STATIC_URL` from `"static/"` to `"/static/"` for proper URL formatting.
* Updated `STATICFILES_DIRS` and `STATIC_ROOT` to use `BASE_DIR / "static"` and `BASE_DIR / "staticfiles"` respectively, switching to path objects for better compatibility and readability.

**Storage backend configuration:**

* Clarified the comment to indicate configuration for both default and staticfiles storage.