### PR TITLE
Data management command for data reconciliation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ backups/
 hugo_site/
 .idea/
 census_schedules.json
+reports/
 
 # Poetry to UV migration backups
 .venv.poetry.backup/

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,6 @@ static-data/
 logs/
 .claude/
 backups/
-CLAUDE.md
-AGENTS.md
 hugo_site/
 .idea/
 census_schedules.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,675 @@
+# AGENTS.md
+
+> For feature specifications, business rules, and domain models, see [SPEC.md](./SPEC.md).
+
+---
+
+## Table of Contents
+
+- [Project Overview](#project-overview)
+- [Tech Stack](#tech-stack)
+  - [Package Management](#package-management)
+  - [Backend](#backend)
+  - [Frontend](#frontend)
+  - [Database](#database)
+- [Project Initialization](#project-initialization)
+- [Project Structure](#project-structure)
+- [Architecture](#architecture)
+  - [System Architecture Diagram](#system-architecture-diagram)
+  - [Database Schema Diagram](#database-schema-diagram)
+  - [REST API Design](#rest-api-design)
+- [Authentication & Authorization](#authentication--authorization)
+  - [User Auth](#user-auth)
+  - [API Auth](#api-auth)
+- [Development Workflow](#development-workflow)
+  - [Version Control](#version-control)
+  - [Database Migrations](#database-migrations)
+  - [Debugging & Logging](#debugging--logging)
+  - [Serving the Application](#serving-the-application)
+  - [Testing Approach](#testing-approach)
+- [Best Practices & Key Conventions](#best-practices--key-conventions)
+- [Notes for AI Agents](#notes-for-ai-agents)
+
+---
+
+## Project Overview
+
+**Religious Ecologies** is a Django-based platform for transcribing, managing, and visualizing historical American religious census data. The project serves historians and researchers at Roy Rosenzweig Center for History and New Media (RRCHNM) at George Mason University.
+
+Core goals:
+- Enable undergraduate/graduate students to transcribe handwritten 1926 Federal Census of Religious Bodies schedules
+- Provide a structured workflow (assignment → transcription → review → approval) for team-based data entry
+- Expose cleaned, structured data via a REST API and interactive public-facing visualizations
+- Support scholarly publication through blog posts, interactive maps, and Observable Plot visualizations
+
+Key users:
+- **Transcribers** (student workers): Assigned census records to transcribe
+- **Reviewers** (PIs, postdocs, staff): Oversee assignments, review transcriptions, approve records
+- **Public**: Browse and explore data via interactive maps, charts, and blog posts
+
+---
+
+## Tech Stack
+
+Python 3.12+ Django application with PostgreSQL, served via Daphne ASGI server. Admin interface customized with Django Unfold. Public frontend uses Foundation CSS, Leaflet.js maps, and Observable Plot for interactive visualizations.
+
+### Package Management
+
+- **Package manager**: `uv` (primary) and `poetry` both work; lock file is `uv.lock`
+- **Python version**: ≥3.12
+- **Key commands**:
+  - `uv run python manage.py <cmd>` or `poetry run python manage.py <cmd>`
+  - `make <target>` — Makefile provides ~40 convenience commands
+- Lock file is committed; resolve conflicts by re-running `uv lock`
+
+### Backend
+
+- **Runtime**: Python 3.12+
+- **Framework**: Django 5.1.4 (async via Daphne 4.1.2+)
+- **Key libraries**:
+  - `djangorestframework` — REST API
+  - `django-filter` — Queryset filtering
+  - `django-unfold` — Admin UI customization
+  - `django-simple-history` — Model change tracking (all major models have `HistoricalRecords`)
+  - `django-allauth` — Authentication with GitHub OAuth support
+  - `django-import-export` — CSV/Excel import/export in admin
+  - `django-tables2` — Table rendering
+  - `django-cors-headers` — CORS support
+  - `whitenoise` — Static file serving
+  - `django-storages` + `boto3` — Optional S3 media storage
+  - `easy-thumbnails` — Automatic image thumbnail generation
+  - `python-dotenv` + `django-environ` — Environment variable management
+  - `markdown` — Markdown rendering for blog/page content
+  - `openpyxl` — Excel file support
+- **API pattern**: RESTful via Django REST Framework
+
+### Frontend
+
+- **CSS framework**: Foundation (via `foundation.js`, `what-input.js`)
+- **Tailwind CSS**: Available via `django-tailwind` with `theme` app; used in some views
+- **Maps**: Leaflet.js for interactive choropleth and marker maps
+- **Visualizations**: Observable Plot 0.6 + D3 v7 loaded from jsDelivr CDN via ES6 import maps (no bundler required)
+- **Admin**: Django Unfold with custom Religious Ecologies blue theme (`#0060b1`)
+- **No JavaScript framework** — vanilla JS with Django template rendering
+
+### Database
+
+- **Database**: PostgreSQL
+- **ORM**: Django ORM (no separate query builder)
+- **Migrations**: Django's built-in migration system
+- **Full-text search**: Not configured; filter-based search via `django-filter`
+- **Caching**: Not configured; no Redis layer
+- **Media storage**: Local filesystem (development), optional S3 (production via `OBJ_STORAGE` env var)
+- **Thumbnails**: `easy-thumbnails` generates 4 sizes: admin (100×75), small (200×150), medium (400×300), large (800×600)
+
+---
+
+## Project Initialization
+
+### Prerequisites
+- Python ≥3.12
+- PostgreSQL
+- `uv` or `poetry`
+- Node.js (for Tailwind CSS compilation, if needed)
+
+### Setup
+
+```bash
+# 1. Clone repository
+git clone <repo-url>
+cd relec-django
+
+# 2. Install dependencies
+uv sync
+# or: poetry install
+
+# 3. Environment configuration
+cp .env.example .env  # Edit with your values
+```
+
+Required environment variables (`.env`):
+```
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=religious_ecologies
+DB_USER=religious_ecologies
+DB_PASS=yourpassword
+SECRET_KEY=your-django-secret-key
+DEBUG=True
+ALLOWED_HOSTS=localhost,127.0.0.1
+```
+
+Optional environment variables:
+```
+GITHUB_CLIENT_ID=...        # GitHub OAuth
+GITHUB_SECRET=...
+OBJ_STORAGE=s3              # Enable S3 media storage
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+AWS_STORAGE_BUCKET_NAME=...
+```
+
+```bash
+# 4. Create database
+createdb religious_ecologies
+
+# 5. Run migrations
+uv run python manage.py migrate
+
+# 6. Set up user groups and permissions
+uv run python manage.py setup_transcription_groups
+
+# 7. Create admin user
+uv run python manage.py createsuperuser
+
+# 8. (Optional) Import reference data
+make import-locations     # Populated places from CSV
+make import-denoms        # Denomination list from CSV
+
+# 9. Start dev server
+uv run python manage.py runserver
+# or: make preview
+```
+
+Access at `http://localhost:8000`. Admin at `http://localhost:8000/admin/`.
+
+### Common Setup Issues
+- **`SynchronousOnlyOperation`**: Django 6.0 ASGI mode; django-debug-toolbar is disabled — don't re-enable it until it supports async
+- **Missing static files**: Run `uv run python manage.py collectstatic`
+- **Thumbnail errors**: Ensure `mediafiles/` directory exists and is writable
+
+---
+
+## Project Structure
+
+```
+relec-django/
+├── config/                    # Django project configuration
+│   ├── settings.py            # Main settings (Unfold config, DB, auth, storage)
+│   ├── urls.py                # Root URL routing
+│   ├── asgi.py                # ASGI application (Daphne)
+│   └── wsgi.py                # WSGI application (fallback)
+│
+├── census/                    # Core transcription app
+│   ├── models.py              # Denomination, CensusSchedule, ReligiousBody, Membership, Clergy
+│   ├── admin.py               # Enhanced admin: bulk actions, workflow filters, quality tools
+│   ├── views.py               # Census browser, map views, denomination/location browsing
+│   ├── api_views.py           # DRF viewsets for REST API
+│   ├── api_root.py            # Custom API documentation root
+│   ├── urls.py                # Census URL patterns
+│   └── management/commands/   # Data import: datascribe, omeka, denominations, export
+│
+├── location/                  # Geographic hierarchy app
+│   ├── models.py              # State, County, PopulatedPlace (+ deprecated Location)
+│   ├── admin.py               # Location admin views
+│   └── management/commands/   # import_locations, link_counties_from_omeka
+│
+├── pages/                     # CMS app
+│   ├── models.py              # Page, BlogPost, Visualization
+│   ├── views.py               # Page/blog/viz detail views
+│   ├── urls.py                # Pages URL patterns
+│   ├── context_processors.py  # Navigation context (nav pages)
+│   └── management/commands/   # Hugo content migration tools
+│
+├── analytics/                 # Reporting & analysis app
+│   ├── views.py               # Dashboard, query builder, analysis views
+│   └── urls.py                # Analytics URL patterns
+│
+├── religious_ecologies/       # Core project app
+│   ├── admin.py               # Custom dashboard context injection
+│   └── apps.py                # AppConfig (loads admin dashboard)
+│
+├── templates/                 # All HTML templates
+│   ├── base.html              # Site-wide base template
+│   ├── index.html             # Home page
+│   ├── admin/                 # Custom admin templates (dashboard, bulk assign, analysis)
+│   ├── census/                # Census browser, detail, map, browse templates
+│   ├── pages/                 # Blog, visualization, static page templates
+│   └── analytics/             # Analytics dashboard template
+│
+├── static/                    # Source static files
+│   ├── css/                   # custom_unfold.css, leaflet.css
+│   ├── js/                    # app.js, foundation.js, what-input.js
+│   ├── images/                # Logos (logo.svg, partner logos, NEH seal)
+│   ├── viz/                   # Observable Plot wrapper scripts
+│   └── data/                  # Data files for visualizations
+│
+├── staticfiles/               # Collected static (production; git-ignored)
+├── mediafiles/                # Uploaded/fetched media (git-ignored)
+│
+├── theme/                     # Tailwind CSS theme app
+│   └── static_src/            # Tailwind source (node_modules here)
+│
+├── static-data/               # CSV source data for imports
+│   ├── denominations.csv
+│   ├── popplaces_1926.csv
+│   └── schedules_with_datascribe.csv
+│
+├── docs/                      # Additional documentation
+│   └── INTERACTIVE_VISUALIZATIONS.md
+│
+├── Makefile                   # Development convenience commands (~40 targets)
+├── pyproject.toml             # Project dependencies (uv/poetry)
+├── uv.lock                    # Locked dependencies
+├── Dockerfile                 # Container build
+├── docker-compose.yml         # Local container composition
+├── manage.py                  # Django entry point
+├── CLAUDE.md                  # AI agent session notes
+├── DEVNOTES.md                # Developer workflow documentation
+└── README.md                  # Quick start guide
+```
+
+---
+
+## Architecture
+
+### System Architecture Diagram
+
+```mermaid
+graph TD
+    Browser[Browser / Public User]
+    Admin[Admin User / Staff]
+
+    Browser -->|HTTP| DjangoViews[Django Views\ncensus / pages / analytics]
+    Admin -->|HTTP| DjangoAdmin[Django Admin\nUnfold-styled]
+
+    DjangoViews -->|Template rendering| Templates[Django Templates\nJinja2-like]
+    DjangoViews -->|REST| DRFAPI[DRF REST API\n/census/api/]
+    DjangoAdmin --> DjangoViews
+
+    Templates -->|Static assets| WhiteNoise[WhiteNoise\nStatic Files]
+    Templates -->|CDN modules| CDN[jsDelivr CDN\nObservable Plot / D3]
+    Templates -->|Tile maps| Leaflet[Leaflet.js\nOpenStreetMap tiles]
+
+    DjangoViews --> ORM[Django ORM]
+    DRFAPI --> ORM
+    DjangoAdmin --> ORM
+
+    ORM --> PostgreSQL[(PostgreSQL)]
+
+    ORM -->|Media upload| Storage{Storage Backend}
+    Storage -->|Dev| LocalFS[Local Filesystem\nmediafiles/]
+    Storage -->|Prod| S3[AWS S3\nOptional]
+
+    DjangoAdmin -->|Auth| Allauth[django-allauth\nDjango Auth + GitHub OAuth]
+    Allauth --> PostgreSQL
+```
+
+### Database Schema Diagram
+
+```mermaid
+erDiagram
+    STATE {
+        char code PK
+        string name
+    }
+
+    COUNTY {
+        int id PK
+        string ahcb_id
+        string name
+        char state_id FK
+    }
+
+    POPULATEDPLACE {
+        int id PK
+        int place_id
+        string name
+        int county_id FK
+        float lat
+        float lon
+    }
+
+    DENOMINATION {
+        int id PK
+        string denomination_id
+        string name
+        string short_name
+        string family_census
+        string family_relec
+    }
+
+    CENSUSSCHEDULE {
+        int id PK
+        int resource_id
+        string schedule_title
+        string schedule_id
+        string transcription_status
+        int assigned_transcriber_id FK
+        int assigned_reviewer_id FK
+        int county_id FK
+        int populated_place_id FK
+        int schedule_denomination_id FK
+        int datascribe_omeka_item_id
+        string omeka_storage_id
+        image original_image
+    }
+
+    RELIGIOUSBODY {
+        int id PK
+        int census_record_id FK
+        int denomination_id FK
+        string name
+        string address
+        float latitude
+        float longitude
+        string geocode_status
+        int num_edifices
+        decimal edifice_value
+        decimal expenses
+        decimal benevolences
+    }
+
+    MEMBERSHIP {
+        int id PK
+        int census_record_id FK
+        int religious_body_id FK
+        int male_members
+        int female_members
+        int total_members_by_sex
+        int members_under_13
+        int members_13_and_older
+        int sunday_school_num_scholars
+    }
+
+    CLERGY {
+        int id PK
+        int census_schedule_id FK
+        string name
+        bool is_assistant
+        string college
+        string theological_seminary
+        int num_other_churches_served
+    }
+
+    PAGE {
+        int id PK
+        string title
+        string slug
+        text content
+        bool is_published
+        bool show_in_nav
+        int nav_order
+    }
+
+    BLOGPOST {
+        int id PK
+        string title
+        string slug
+        string author
+        datetime published_date
+        text content
+        text abstract
+        image thumbnail_image
+        bool is_draft
+    }
+
+    VISUALIZATION {
+        int id PK
+        string title
+        string slug
+        string author
+        text content
+        text abstract
+        image thumbnail_image
+        string script_file
+        string doi
+    }
+
+    STATE ||--o{ COUNTY : "has"
+    COUNTY ||--o{ POPULATEDPLACE : "contains"
+    COUNTY ||--o{ CENSUSSCHEDULE : "schedules in"
+    POPULATEDPLACE ||--o{ CENSUSSCHEDULE : "schedules for"
+    DENOMINATION ||--o{ CENSUSSCHEDULE : "denomination of"
+    CENSUSSCHEDULE ||--o{ RELIGIOUSBODY : "contains"
+    CENSUSSCHEDULE ||--o{ MEMBERSHIP : "records"
+    CENSUSSCHEDULE ||--o{ CLERGY : "lists"
+    RELIGIOUSBODY ||--o{ MEMBERSHIP : "has"
+    DENOMINATION ||--o{ RELIGIOUSBODY : "identifies"
+```
+
+**App summaries:**
+
+- **`location`**: Geographic reference data. `State → County → PopulatedPlace` is the single source of truth for all location data. The legacy `Location` model is deprecated and should not be used in new code.
+- **`census`**: The core data app. `CensusSchedule` is the top-level transcription unit (one schedule image = one record). Each schedule has one or more `ReligiousBody` entities, each with `Membership` statistics and associated `Clergy`.
+- **`pages`**: CMS content. `Page` for static site pages, `BlogPost` for scholarly blog posts, `Visualization` for featured interactive visualizations.
+
+### REST API Design
+
+Base URL: `/census/api/`
+
+All endpoints are publicly readable (no auth required). Pagination is 100 items/page.
+
+```
+GET /census/api/
+    → API root with links to all endpoints
+
+GET /census/api/religious-bodies/
+GET /census/api/religious-bodies/<id>/
+    → ReligiousBody list/detail
+    → Filters: denomination, county, populated_place, geocode_status
+    → Search: name, denomination name
+    → Order: name, denomination
+
+GET /census/api/denominations/
+GET /census/api/denominations/<id>/
+    → Denomination list/detail
+    → Search: name, short_name, family_census, family_relec
+```
+
+**Response format (list):**
+```json
+{
+  "count": 1234,
+  "next": "http://.../?page=2",
+  "previous": null,
+  "results": [ ... ]
+}
+```
+
+**Common query parameters:**
+- `?page=N` — pagination
+- `?search=term` — full-text search
+- `?ordering=field` — sort by field (prefix `-` for descending)
+
+---
+
+## Authentication & Authorization
+
+### User Auth
+
+- **Strategy**: Django session-based authentication + `django-allauth`
+- **Providers**: Username/password (default Django) and GitHub OAuth
+- **Login URL**: `/accounts/login/`
+- **Admin login**: `/admin/login/` (redirects to `/admin/`)
+- **Sessions**: Database-backed (default Django session engine)
+- **Password hashing**: Django default (PBKDF2)
+
+**User Groups** (set up via `setup_transcription_groups` command):
+
+| Group | Description |
+|-------|-------------|
+| Transcribers | Student workers; can add/edit; see only assigned records |
+| Reviewers | PIs/staff; full add/edit/delete; see all records |
+| Superusers | Full Django admin access |
+
+**Transcription workflow permissions:**
+- Transcribers: `census.add_censusschedule`, `census.change_censusschedule`, add/change on related models
+- Reviewers: Full CRUD on all census models
+
+### API Auth
+
+- **Authentication**: None required — API is publicly readable
+- **Write access**: Not exposed via API; all data modification is through Django admin
+- **CORS**: Configured via `django-cors-headers` (check `CORS_ALLOWED_ORIGINS` in settings)
+- **Rate limiting**: Not configured
+- **Security headers**: Django's default security middleware (`SecurityMiddleware`)
+
+---
+
+## Development Workflow
+
+### Version Control
+
+- **Branching model**: Feature branches off `main`
+- **Branch naming**:
+  - `feat/description` — new features
+  - `fix/description` — bug fixes
+  - `refactor/description` — code cleanup
+- **Commit format**: Conventional Commits (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`)
+- **Main branch**: `main` — protected; deploy target
+
+### Database Migrations
+
+- **Tool**: Django's built-in migration system
+- **Create migration**: `uv run python manage.py makemigrations <app>`
+- **Apply migrations**: `uv run python manage.py migrate`
+- **Makefile shortcuts**: `make mm` (makemigrations), `make migrate`
+
+Best practices:
+- Never edit a migration that has been applied to production
+- Data migrations go in separate migration files from schema migrations
+- Test migrations both forward and in reverse before committing
+- The `location` app had a significant refactor (migration 0016 removed `ReligiousBody.location` FK) — do not reintroduce the old `Location` FK pattern
+
+### Debugging & Logging
+
+- **django-debug-toolbar**: Disabled (Django 6.0 async incompatibility). Do not re-enable until the toolbar releases Django 6.0 support.
+- **Django shell**: `uv run python manage.py shell` or `make shell`
+- **Logging**: Django's default logging to console; check `LOGGING` in `settings.py`
+- **Log levels**: `DEBUG` in development, `INFO`/`WARNING` in production
+
+### Serving the Application
+
+**Development:**
+```bash
+uv run python manage.py runserver
+# or
+make preview
+```
+- Runs at `http://localhost:8000`
+- Uses Daphne ASGI server via `manage.py runserver`
+
+**Static files in development:**
+- Served by Django's `runserver` from `STATICFILES_DIRS`
+- After changes to Tailwind, run: `uv run python manage.py tailwind build`
+
+**Production:**
+```bash
+uv run python manage.py collectstatic
+# Deploy via Daphne or gunicorn with a reverse proxy (nginx)
+```
+- Static files served by WhiteNoise
+- Media files: local filesystem or S3 (set `OBJ_STORAGE=s3`)
+- Configure `ALLOWED_HOSTS`, `DEBUG=False`, and a strong `SECRET_KEY`
+
+**Docker:**
+```bash
+docker-compose up
+```
+
+### Testing Approach
+
+- **Framework**: `pytest-django`
+- **Run tests**: `uv run pytest`
+- **Test location**: `tests/` directory (currently minimal coverage)
+- **Coverage**: No minimum enforced; expand test coverage for new features
+- **Patterns**: Standard Django TestCase for model/view tests; use `pytest.mark.django_db` decorator
+
+---
+
+## Best Practices & Key Conventions
+
+**Code Style:**
+- Formatter: `black` (line length 88)
+- Pre-commit hooks configured (`pre-commit`)
+- HTML formatter: `djhtml`
+
+**Naming Conventions:**
+- Python: PEP 8 (snake_case variables/functions, PascalCase classes)
+- Templates: kebab-case filenames
+- URL names: `app_name:view_name` pattern (e.g., `census:browser`)
+- Migration files: Auto-generated by Django (do not rename)
+
+**Model Conventions:**
+- All models include `created_at` / `updated_at` timestamps
+- All major models use `django-simple-history` (`HistoricalRecords`) for change tracking
+- Use `PROTECT` on foreign keys to prevent accidental cascades (except `CASCADE` on child records that must be deleted with parent)
+
+**Location Hierarchy (Critical):**
+- **Always** use `State → County → PopulatedPlace` — never reference the deprecated `Location` model
+- Access location via `census_record.county.state` and `census_record.populated_place`
+- Key `select_related` pattern:
+  ```python
+  ReligiousBody.objects.select_related(
+      "census_record__populated_place__county__state",
+      "census_record__county__state",
+      "denomination",
+  )
+  ```
+
+**API Patterns:**
+- DRF ViewSets for standard CRUD; custom views for complex queries
+- Always use `select_related` / `prefetch_related` on querysets to avoid N+1 queries
+- Filter via `django-filter` FilterSets, not manual query parameter parsing
+
+**Admin Patterns:**
+- Custom admin views extend `AdminSite.admin_view()` for permission checks
+- Bulk actions defined as methods on `ModelAdmin` with `short_description`
+- Smart queryset filtering: override `get_queryset()` to scope by user group
+
+**Visualizations:**
+- Observable Plot visualizations use wrapper scripts (hardcoded div IDs, no params system)
+- Import maps in `blog_detail.html` resolve `@observablehq/plot` and `d3` from CDN
+- Each visualization is a standalone ES6 module — no global state
+
+---
+
+## Notes for AI Agents
+
+**Preferred Patterns:**
+- Use `uv run python manage.py` (or `make` targets) for all management commands
+- Prefer `select_related` / `prefetch_related` over multiple queries
+- Follow the existing `ModelAdmin` patterns in `census/admin.py` for new admin views
+- Use Django's `messages` framework for user feedback in admin views
+
+**Critical Context:**
+- `ReligiousBody.location` FK **does not exist** — it was removed in migration 0016. Never add it back.
+- `django-debug-toolbar` is disabled intentionally — do not re-enable or add debug toolbar middleware
+- The `Location` model in `location/models.py` is deprecated — use `State`, `County`, `PopulatedPlace`
+- Observable Plot visualizations use wrapper scripts with hardcoded div IDs; do not reintroduce the `@params` import system
+
+**Ongoing Migrations/Debt:**
+- The `analytics` app has views but no models — planned future expansion
+- Some blog posts still reference legacy `featured_image` CharField; prefer `thumbnail_image` ImageField
+- The Tailwind CSS integration (`theme` app) is available but not used consistently across all templates
+
+**When Making Changes:**
+- Run `uv run python manage.py check` after changes to catch configuration errors
+- Run `uv run pytest` to verify nothing is broken
+- After model changes, always run `makemigrations` and `migrate`
+- Update `select_related` chains when adding new FK relationships to models used in list views
+
+**What to Avoid:**
+- Do not use synchronous ORM operations in async views (use `sync_to_async` or `aaync` ORM methods)
+- Do not add `ReligiousBody.location` or any reference to the deprecated flat `Location` model
+- Do not install `django-debug-toolbar` or add it to `INSTALLED_APPS`
+- Do not create new standalone JavaScript frameworks/bundlers — the project intentionally avoids bundlers
+- Do not add rate limiting without first checking if it affects the public-read API requirements
+
+**File Modification Guidelines:**
+- `census/models.py`: Contains the main workflow state machine; update `TRANSCRIPTION_STATUS_CHOICES` and `save()` auto-transition logic together
+- `config/settings.py`: UNFOLD config is large; keep sidebar navigation groups organized by the existing 6 sections
+- `templates/admin/index.html`: Custom dashboard; metrics are injected via `religious_ecologies/admin.py`
+- Location filters in admin use `census_record__populated_place` and `census_record__county` paths — maintain this pattern
+
+**Common Pitfalls:**
+- Forgetting `select_related` on `census_record__populated_place__county__state` causes many N+1 queries in list views
+- The `census_record` FK on `ReligiousBody` is `CASCADE`; deleting a `CensusSchedule` deletes all its `ReligiousBody`, `Membership`, and `Clergy` records
+- `PopulatedPlace.place_id` is nullable (not all places have Apiary IDs); use `pk` for URL routing and internal references
+- GitHub OAuth requires `GITHUB_CLIENT_ID` and `GITHUB_SECRET` env vars; without them, social login is unavailable but regular auth still works
+
+---
+
+*Last Updated: 2026-02-19*
+*This document is maintained for AI agent context and onboarding.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,237 +1,116 @@
 # Religious Ecologies Project - Claude Code Session Notes
 
+> For full technical documentation see [AGENTS.md](./AGENTS.md). For feature specs and domain rules see [SPEC.md](./SPEC.md).
+
 ## Project Overview
 Django project for managing historical religious census data transcription with undergraduate/graduate student workers.
 
-## Recent Implementation: Complete Project Management System + Enhanced Admin
+---
 
-### ✅ Completed Work
+## Implemented Features
 
-#### 1. Lightweight Project Management System
-**Files Modified:**
-- `census/models.py` - Added transcription workflow fields to CensusSchedule model
-- `census/admin.py` - Enhanced admin with project management features
-- `census/management/commands/setup_transcription_groups.py` - User group setup command
-
-**Features Implemented:**
+### Project Management System
 - **Status Workflow**: `unassigned` → `assigned` → `in_progress` → `needs_review` → `completed` → `approved`
-- **User Assignments**: `assigned_transcriber` and `assigned_reviewer` fields
-- **Auto-status Logic**: Records auto-transition when assignments change
-- **Permissions**: Students (Transcribers group) can add/edit but not delete; PIs (Reviewers group) have full access
+- **User Assignments**: `assigned_transcriber` and `assigned_reviewer` fields on `CensusSchedule`
+- **Auto-status Logic**: Records auto-transition from `unassigned` → `assigned` when a transcriber is set
+- **Permissions**: Transcribers (students) can add/edit but not delete; Reviewers (PIs) have full access; Transcribers see only their assigned records
 
-#### 2. Django-Unfold Admin Enhancements
-**Files Modified:**
-- `config/settings.py` - Added comprehensive UNFOLD configuration with Religious Ecologies branding
-- `templates/admin/index.html` - Custom dashboard with charts and metrics
-- `religious_ecologies/admin.py` - Dashboard context injection
-- `religious_ecologies/apps.py` - App config for admin loading
-- `static/css/custom_unfold.css` - Custom Religious Ecologies blue theme (#0060b1)
+### Django-Unfold Admin
+- Custom dashboard (`templates/admin/index.html`) with metrics, charts, activity feed
+- Organized sidebar: Dashboard, Analytics, Transcriptions, Location Data, Content Management, System Admin
+- Religious Ecologies blue theme (`#0060b1`) via `static/css/custom_unfold.css`
+- Dashboard context injected via `religious_ecologies/admin.py`
 
-**Features Implemented:**
-- **Organized Sidebar**:
-  - Dashboard
-  - Data Quality Tools (Schedule ID gaps, Missing counties)
-  - Transcription Project (census schedules, religious bodies, membership, clergy)
-  - Reference Data (denominations, locations)
-  - Content Management (pages)
-  - System Administration (users, groups - tucked away)
-- **Interactive Dashboard**:
-  - Key metrics (total records, transcribed count, completion %)
-  - Visual charts (status distribution, work distribution)
-  - Recent activity feed with status badges
-- **Religious Ecologies Branding**: Logo integration and custom blue color scheme
+### Bulk Assignment System
+- Multi-record selection → assign transcriber + reviewer + status in one operation
+- Quick actions: "Assign to me," remove transcriber/reviewer
+- Data quality tools: Schedule ID gap analysis, missing county analysis
+- Templates: `templates/admin/census/bulk_assign.html`, `schedule_gap_analysis.html`, `missing_county_analysis.html`
 
-#### 3. Complete Bulk Assignment System
-**Files Modified:**
-- `census/admin.py` - Added comprehensive bulk actions and custom views
-- `templates/admin/census/bulk_assign.html` - Professional bulk assignment interface
-- `templates/admin/census/schedule_gap_analysis.html` - Schedule ID gap analysis
-- `templates/admin/census/missing_county_analysis.html` - County data completeness analysis
-
-**Features Implemented:**
-- Status changes: Mark as unassigned/assigned/in progress/needs review/transcribed/approved
-- Assignments: Assign to me, remove transcriber/reviewer assignments
-- **Advanced bulk assign form**: Multi-user assignment with status changes
-- **Data Quality Tools**: Gap analysis and location data validation
-
-#### 4. Enhanced Admin Filtering & User Permissions
-**Features Implemented:**
-- **Smart Record Filtering**: Students see only assigned records, PIs see all records
-- **Enhanced Filters**: Workflow filters, assignment status filters, location filters
-- **User Permission Logic**: Intelligent access control based on group membership
-- **Auto-save Logic**: Student work automatically transitions to "needs review" status
-
-### 🔨 Commands for Setup
-```bash
-# Run migrations
-poetry run python manage.py migrate
-
-# Set up user groups and permissions
-poetry run python manage.py setup_transcription_groups
-
-# Check configuration
-poetry run python manage.py check
-```
-
-### 📋 System Ready for Production Use
-
-#### ✅ All Core Features Complete
-- Bulk assignment system fully functional with professional interface
-- User permissions system operational and tested
-- Data quality analysis tools integrated
-- Admin interface fully customized with Religious Ecologies branding
-
-#### 🔧 Setup Required for New Deployments
-- Add users to "Transcribers" and "Reviewers" groups via Django admin
-- Configure user permissions for project team members
-- Test workflow with actual transcription data
-
-#### 💡 Future Enhancement Opportunities
-- Email notifications for status changes
-- Deadline tracking for assignments
-- Progress reporting views for individual users
-- Student dashboard showing personal assigned work
-- Advanced batch assignment by location/denomination filters
-
-### 🗂️ Key File Locations
-```
-├── census/
-│   ├── models.py (CensusSchedule with workflow fields)
-│   ├── admin.py (Complete admin with bulk actions, filters, custom views)
-│   └── management/commands/setup_transcription_groups.py
-├── config/settings.py (UNFOLD configuration with Religious Ecologies branding)
-├── templates/admin/
-│   ├── index.html (Custom dashboard)
-│   └── census/
-│       ├── bulk_assign.html (Bulk assignment interface)
-│       ├── schedule_gap_analysis.html (Gap analysis tool)
-│       └── missing_county_analysis.html (County analysis tool)
-├── static/css/custom_unfold.css (Religious Ecologies blue theme)
-├── religious_ecologies/
-│   ├── admin.py (Dashboard context)
-│   └── apps.py (App config)
-└── DEVNOTES.md (Comprehensive user permission documentation)
-```
-
-### 🎯 Final Status Summary
-- ✅ Complete project management workflow implemented and tested
-- ✅ Professional admin interface with Religious Ecologies branding
-- ✅ Interactive dashboard with metrics and charts
-- ✅ Full bulk assignment system with professional interface
-- ✅ Data quality analysis tools (Schedule gaps, County completeness)
-- ✅ Smart user permission system (Students see assigned records, PIs see all)
-- ✅ Enhanced filtering and workflow management
-- ✅ Comprehensive documentation in DEVNOTES.md
-
-### 🔧 Development Commands
-```bash
-# Poetry environment
-poetry run python manage.py [command]
-
-# Key commands used
-poetry run python manage.py makemigrations census
-poetry run python manage.py migrate
-poetry run python manage.py setup_transcription_groups
-poetry run python manage.py check
-```
-
-The project now has a professional transcription management interface with workflow tracking, team assignments, and administrative oversight capabilities. The main remaining work is finishing the bulk assignment template and setting up user groups for testing.
+### Smart Admin Filtering
+- Students see only records where `assigned_transcriber = current_user`
+- PIs see all records
+- Workflow filters, assignment status filters, location filters
 
 ---
 
-## Django 6.0 Async Compatibility Fix (Feb 2026)
+## Commands
+
+```bash
+# Preferred: uv (poetry also works)
+uv run python manage.py migrate
+uv run python manage.py makemigrations census
+uv run python manage.py setup_transcription_groups
+uv run python manage.py check
+```
+
+Setup for new deployments:
+1. Run migrations
+2. Run `setup_transcription_groups`
+3. Add users to "Transcribers" and "Reviewers" groups via Django admin
+
+---
+
+## Daphne/ASGI Async Compatibility
 
 ### Issue
-Django 6.0 runs in async mode by default (via ASGI), causing `SynchronousOnlyOperation` errors with django-debug-toolbar.
+Django 5.1 running via Daphne in async (ASGI) mode causes `SynchronousOnlyOperation` errors with django-debug-toolbar.
 
 ### Solution
-**Disabled django-debug-toolbar** for Django 6.0 compatibility:
-- Commented out in `config/settings.py`:
-  - `INSTALLED_APPS += ["debug_toolbar"]`
-  - `MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]`
-- Updated `config/urls.py` to conditionally include debug toolbar only if in INSTALLED_APPS
+**Disabled django-debug-toolbar:**
+- Commented out in `config/settings.py`: `INSTALLED_APPS += ["debug_toolbar"]` and the middleware line
+- `config/urls.py` conditionally includes toolbar only if it's in `INSTALLED_APPS`
 
-**Why:** Django Debug Toolbar makes synchronous database queries in its panels, which conflicts with Django 6.0's async context. The toolbar needs updates for full Django 6.0 compatibility.
-
-**What Still Works:**
-- ✅ Django Admin with Unfold styling
-- ✅ Custom dashboard with metrics and charts
-- ✅ All transcription management features
-- ✅ Bulk assignment system
-
-**To Re-enable Later:** Wait for django-debug-toolbar to release Django 6.0 compatible version, then uncomment the lines in settings.py.
+**To re-enable later:** Wait for django-debug-toolbar to release Daphne/ASGI-compatible version, then uncomment the lines in `settings.py`.
 
 ---
 
 ## Interactive Visualizations with Observable Plot
 
-### ✅ Completed Work (Feb 2026)
+### Current Approach (Simplified)
+Each visualization has a **wrapper script** with the target div ID hardcoded as a constant. No global state, no params resolution, no data URLs — just straightforward ES6 modules.
 
-**Problem:** Blog posts migrated from Hugo had interactive visualizations using Observable Plot.js, but the ES6 module imports weren't working in Django without a bundler.
+```javascript
+// Example: static/viz/denominational-diversity-wrapper.js
+import * as Plot from "@observablehq/plot";
+import { data } from "./denominational-diversity-data.js";
 
-**Solution Implemented:**
-- Added **import maps** to `templates/pages/blog_detail.html` to load Observable Plot and D3 from CDN
-- Updated `static/viz/params.js` to dynamically get visualization div IDs from a global params object
-- Modified `pages/management/commands/convert_hugo_shortcodes.py` to inject params setup script before viz loads
-- Created `pages/management/commands/fix_interactive_viz.py` to update already-converted posts
+const TARGET_DIV = "denominational-diversity";
+const plot = Plot.plot({ ... });
+document.getElementById(TARGET_DIV).appendChild(plot);
+```
 
-**Files Modified:**
-- `templates/pages/blog_detail.html` - Added import map for `@observablehq/plot` and `d3` from jsDelivr CDN, plus styling for `.viz-interactive` figures
-- `static/viz/params.js` - Updated to read div ID from `window.__vizParams` global object set by inline script
-- `pages/management/commands/convert_hugo_shortcodes.py` - Enhanced `convert_fig_interactive()` to inject params setup
-- `pages/management/commands/fix_interactive_viz.py` - New command to update existing posts with new HTML structure
+Import maps in `templates/pages/blog_detail.html` resolve `@observablehq/plot` (0.6) and `d3` (v7) from jsDelivr CDN — no bundler needed.
 
-**How It Works:**
-1. Hugo shortcode `{{< fig-interactive id="..." script="..." caption="..." title="..." >}}` converts to HTML `<figure>` with:
-   - A `<div id="..." class="viz-container">` for the visualization
-   - An inline wrapper `<script type="module">` that:
-     - Creates a data URL blob exporting `{ id: 'div-id' }` as a module
-     - Fetches the viz script, replaces `@params` import with the data URL
-     - Creates another blob URL for the modified script and dynamically imports it
-   - Import map in page header resolves `@observablehq/plot` and `d3` from CDN
-
-2. Visualization scripts (e.g., `denominational-diversity.js`) import Plot.js and params:
-   ```javascript
-   import * as Plot from "@observablehq/plot";
-   import * as params from "@params";  // Replaced at runtime with data URL
-   // ... creates plot ...
-   document.getElementById(params.id).appendChild(plot);
-   ```
-
-3. Each figure gets its own isolated params module via data URL
-   - No global state means multiple visualizations work independently
-   - The `@params` import is replaced at fetch-time with a unique blob URL per figure
-
-**Posts with Interactive Visualizations:**
-- `overview-of-cities-data` - 2 Plot.js visualizations (denominational diversity, membership proportion)
-- `american-rescue-workers` - Interactive visualizations
+**Adding new visualizations:** See `docs/INTERACTIVE_VISUALIZATIONS.md`.
 
 **Commands:**
 ```bash
-# Fix existing converted posts (already run)
-uv run python manage.py fix_interactive_viz
-
-# Convert new Hugo posts with shortcodes
-uv run python manage.py convert_hugo_shortcodes
+uv run python manage.py fix_interactive_viz      # Update existing posts
+uv run python manage.py convert_hugo_shortcodes  # Convert new Hugo posts
 ```
 
-**Key Technical Details:**
-- Uses ES6 import maps (no bundler needed) - modern browser feature
-- Observable Plot loaded from `https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6/+esm`
-- D3 loaded from `https://cdn.jsdelivr.net/npm/d3@7/+esm`
-- Each visualization uses a wrapper script with hardcoded div ID (no params system needed)
-- CSS styling in blog_detail.html provides consistent figure appearance
+---
 
-**Current Implementation (Simplified):**
-After several iterations, we settled on the simplest approach:
-- Each visualization has a wrapper script (e.g., `denominational-diversity-wrapper.js`)
-- The wrapper has the target div ID hardcoded as a constant
-- No global state, no params resolution, no data URLs
-- Just straightforward ES6 modules that import Plot, import data, create viz, append to div
+## Key File Locations
 
-**Adding New Interactive Visualizations:**
-See detailed guide in `docs/INTERACTIVE_VISUALIZATIONS.md` for complete instructions on:
-- Creating data files
-- Writing wrapper scripts
-- Adding HTML to blog posts
-- Troubleshooting common issues
+```
+census/
+  models.py                          — CensusSchedule with workflow fields
+  admin.py                           — Bulk actions, filters, custom views
+  management/commands/
+    setup_transcription_groups.py    — Creates Transcribers/Reviewers groups
+config/settings.py                   — UNFOLD config, DB, auth, storage
+templates/admin/
+  index.html                         — Custom dashboard
+  census/
+    bulk_assign.html                 — Bulk assignment interface
+    schedule_gap_analysis.html       — Gap analysis tool
+    missing_county_analysis.html     — County analysis tool
+static/css/custom_unfold.css         — Religious Ecologies blue theme
+religious_ecologies/
+  admin.py                           — Dashboard context injection
+  apps.py                            — AppConfig
+DEVNOTES.md                          — User permission documentation
+docs/INTERACTIVE_VISUALIZATIONS.md  — Guide for adding Observable Plot vizzes
+```

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,560 @@
+# SPEC.md
+
+> For technical implementation details, architecture, and developer documentation, see [AGENTS.md](./AGENTS.md).
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Users & Roles](#users--roles)
+- [Business Rules](#business-rules)
+- [Features](#features)
+- [User Flows](#user-flows)
+  - [Flow 1: Transcribing a Census Schedule](#flow-1-transcribing-a-census-schedule)
+  - [Flow 2: Reviewing and Approving Transcriptions](#flow-2-reviewing-and-approving-transcriptions)
+  - [Flow 3: Bulk Assigning Records](#flow-3-bulk-assigning-records)
+  - [Flow 4: Browsing Census Data (Public)](#flow-4-browsing-census-data-public)
+- [Out of Scope](#out-of-scope)
+- [Open Questions](#open-questions)
+
+---
+
+## Overview
+
+**Religious Ecologies** is a web platform for digitizing and publishing the 1926 Federal Census of Religious Bodies. The census captured detailed statistics on American churches — membership counts, clergy information, property values, and school enrollments — at the congregation level. This project makes that data searchable, analyzable, and publicly accessible.
+
+**Problem it solves:** The original census schedules exist as scanned images in Omeka. Without a structured transcription workflow, the data cannot be queried, mapped, or used for historical analysis.
+
+**Core value proposition:**
+1. A managed transcription pipeline that assigns student workers to specific records and tracks progress through review and approval
+2. A clean, structured dataset exposed via REST API and interactive public visualizations
+3. A scholarly publication platform (blog + visualizations) for communicating findings
+
+**Target audiences:**
+- **Research team** (PIs, postdocs, students) at RRCHNM: primary users of the admin/transcription system
+- **Historians and researchers**: Access data via the public browser and API
+- **General public**: Explore interactive maps and read scholarly blog posts
+
+**Success metrics:**
+- Percentage of census schedules with `transcription_status = approved`
+- Number of `ReligiousBody` records with geocoded coordinates
+- Public API usage and data downloads
+
+---
+
+## Users & Roles
+
+### Principal Investigators / Reviewers
+
+Full access to the system. Responsible for project oversight, data quality, and scholarly output.
+
+**Can:**
+- View all census schedules regardless of assignment
+- Assign records to transcribers and reviewers
+- Bulk-assign records by denomination, location, or status
+- Edit any record at any status
+- Approve finalized transcriptions (`approved` status)
+- Access all admin tools: gap analysis, missing county analysis, export
+- Create and publish blog posts, pages, and visualizations
+- Manage user accounts and group memberships
+
+**Cannot:**
+- Delete records without superuser access (extra protection against accidental data loss)
+
+**Typical persona:** History faculty, postdoctoral researcher, project manager
+
+---
+
+### Transcribers
+
+Student workers (undergraduate or graduate) assigned specific records for data entry.
+
+**Can:**
+- View only their assigned census schedules
+- Enter transcription data: ReligiousBody details, Membership statistics, Clergy information
+- Mark records as needing review when finished
+- Add transcription notes
+
+**Cannot:**
+- See records assigned to other transcribers
+- Assign records to themselves or others
+- Delete records
+- Access data quality tools or export functions
+- Approve records
+
+**Typical persona:** Undergraduate research assistant, graduate student
+
+---
+
+### Public Users (Unauthenticated)
+
+Anyone accessing the public-facing website.
+
+**Can:**
+- Browse census records by state, county, and populated place
+- View individual census record details
+- Explore interactive maps (denomination distribution, demographics, urban congregations)
+- Use the REST API to query records
+- Read blog posts and scholarly visualizations
+- Browse denomination and location indexes
+
+**Cannot:**
+- Access the admin interface
+- Modify any data
+- See records that haven't been transcribed
+
+---
+
+### Superusers
+
+IT/infrastructure administrators with full Django admin access.
+
+**Can:** Everything, including user management, permission changes, and destructive operations.
+
+---
+
+### Permission Matrix
+
+| Action | Superuser | Reviewer | Transcriber | Public |
+|--------|-----------|----------|-------------|--------|
+| View all records | ✓ | ✓ | Own only | Published only |
+| Transcribe records | ✓ | ✓ | Assigned only | ✗ |
+| Assign records | ✓ | ✓ | ✗ | ✗ |
+| Approve records | ✓ | ✓ | ✗ | ✗ |
+| Delete records | ✓ | ✗ | ✗ | ✗ |
+| Bulk assignment tools | ✓ | ✓ | ✗ | ✗ |
+| Data quality tools | ✓ | ✓ | ✗ | ✗ |
+| Export data | ✓ | ✓ | ✗ | API only |
+| Manage users/groups | ✓ | ✗ | ✗ | ✗ |
+| Publish blog/pages | ✓ | ✓ | ✗ | ✗ |
+
+---
+
+## Business Rules
+
+### Transcription Workflow
+
+- A census schedule progresses through exactly these statuses in order:
+  `unassigned → assigned → in_progress → needs_review → completed → approved`
+- Status can be set backward by Reviewers (e.g., returning a `needs_review` record to `in_progress`)
+- A schedule is **automatically** moved from `unassigned` to `assigned` when a transcriber is assigned
+- Transcribers cannot change status beyond `needs_review`; only Reviewers can set `completed` or `approved`
+- A schedule must have at least one `ReligiousBody` record before it can be marked `needs_review`
+
+### Location Hierarchy
+
+- All geographic data follows the strict hierarchy: `State → County → PopulatedPlace`
+- A `CensusSchedule` may have a `county` without a `populated_place` (county-level only) but not vice versa
+- A `PopulatedPlace` must belong to a `County`; a `County` must belong to a `State`
+- Location data on `ReligiousBody` (latitude/longitude) is derived from geocoding the congregation's address — it is not the same as the schedule's `populated_place`
+
+### Geocoding Rules
+
+- `ReligiousBody.geocode_status` values: `pending`, `success`, `failed`, `skipped`
+- Geocoding is not automatic; it is triggered by a management command or admin action
+- Records with `geocode_status = success` are eligible for display on public maps
+
+### Record Visibility
+
+- Transcribers see only records where `assigned_transcriber = current_user`
+- Reviewers and superusers see all records
+- Public-facing views show only records with sufficient data (at least one linked `ReligiousBody`)
+
+### Data Integrity
+
+- Deleting a `CensusSchedule` cascades to delete all linked `ReligiousBody`, `Membership`, and `Clergy` records
+- `Denomination`, `State`, `County`, and `PopulatedPlace` records use `PROTECT` on foreign keys — they cannot be deleted while referenced
+- All major model changes are tracked via `django-simple-history`; a full audit trail is maintained
+
+### Import Rules
+
+- The data import pipeline must be run in order:
+  1. Import denominations
+  2. Import locations (populated places)
+  3. Import census schedules (DataScribe data)
+  4. Import image paths
+  5. Fetch images from Omeka
+  6. Link counties from Omeka metadata
+- Re-running imports is safe; records are matched by stable identifiers (`denomination_id`, `resource_id`, `ahcb_id`)
+
+---
+
+## Features
+
+### Feature: Transcription Admin Interface
+
+**Description:**
+A customized Django admin interface (using Django Unfold) tailored for the transcription workflow. The primary workspace for all research team members.
+
+**User Value:**
+Provides a professional, organized interface for managing the transcription project without requiring custom application development.
+
+**Functionality:**
+- Dashboard with key metrics: total records, transcribed count, completion percentage, recent activity
+- Organized sidebar navigation with 6 sections: Dashboard, Analytics, Transcriptions, Location Data, Content Management, System Admin
+- Census schedule list with smart filtering by status, assignment, denomination, location
+- Transcribers see only their assigned records; Reviewers see all
+- Inline editing of `ReligiousBody`, `Membership`, and `Clergy` records within a schedule
+- Bulk actions: mark records as various statuses, assign/unassign transcribers
+- Change history visible for all records
+
+**User Interactions:**
+- Admin user logs in → sees dashboard with progress metrics
+- Transcriber selects a record → edits fields inline → marks as "needs review"
+- Reviewer filters by "needs review" → opens record → approves or returns with notes
+- PI views dashboard → monitors team progress
+
+**Success Criteria:**
+- Transcribers can complete a record without PI assistance
+- Reviewers can approve a batch of 20 records in under 30 minutes
+- Dashboard accurately reflects real-time project status
+
+---
+
+### Feature: Bulk Assignment System
+
+**Description:**
+A dedicated admin interface for efficiently assigning multiple census schedules to transcribers and reviewers at once.
+
+**User Value:**
+Eliminates the tedious work of assigning records one by one at the start of each work session.
+
+**Functionality:**
+- Multi-select records from the admin list view using Django's built-in checkbox selection
+- Bulk assignment form shows a list of all Transcribers and Reviewers with checkboxes
+- Simultaneously assign a transcriber, assign a reviewer, and set a target status in one operation
+- Quick actions: "Assign to me," "Remove transcriber," "Remove reviewer"
+- Confirmation screen shows how many records will be affected before committing
+- Filter records before bulk assignment by state, county, denomination, or current status
+
+**Edge Cases:**
+- Records already assigned to someone: Show warning, allow override or skip
+- No users in Transcribers group: Show error with link to user management
+
+---
+
+### Feature: Data Quality Tools
+
+**Description:**
+Admin-only analysis tools for identifying gaps and inconsistencies in the census schedule data.
+
+**User Value:**
+Helps PIs identify data problems before they affect analysis or publication.
+
+**Functionality:**
+
+**Schedule ID Gap Analysis:**
+- Lists gaps in the sequential `schedule_id` numbering
+- Helps identify missing or unimported schedules
+- Exportable as CSV
+
+**Missing County Analysis:**
+- Lists schedules that have no linked county or populated place
+- Groups by count to prioritize cleanup effort
+- Shows denomination distribution of un-located records
+
+**Success Criteria:**
+- Tool runs in under 10 seconds for full dataset
+- Results accurately reflect current database state
+
+---
+
+### Feature: Census Browser (Public)
+
+**Description:**
+A public-facing interface for browsing the transcribed census data by geography.
+
+**User Value:**
+Allows historians and the general public to explore the data without needing API knowledge.
+
+**Functionality:**
+- Cascading dropdown filters: State → County → Populated Place
+- Results list shows denomination, location, membership totals
+- Links to individual record detail pages
+- Pagination for large result sets
+- URL structure supports direct linking (e.g., `/census/browser/NY/Kings/`)
+
+**User Interactions:**
+- User selects a state → county dropdown populates → place dropdown populates → records list updates
+- User clicks a record → navigates to full detail page with all transcribed fields
+- User bookmarks a filtered URL → lands on same filtered view
+
+**Edge Cases:**
+- State with no transcribed records: Shows empty state message
+- Very large county (e.g., Cook County, IL): Paginated results with count shown
+
+---
+
+### Feature: Interactive Maps
+
+**Description:**
+Leaflet.js-based maps showing congregation density, denomination distribution, and demographic patterns.
+
+**User Value:**
+Spatial visualization reveals geographic patterns invisible in tabular data.
+
+**Functionality:**
+
+**Denomination Distribution Map** (`/census/map/`):
+- Choropleth map of denominations by county
+- Color-coded by denomination family
+- Clickable counties with popup showing top denominations and member counts
+
+**Demographics Map** (`/census/demographics-map/`):
+- Member counts by geography
+- Toggle between raw counts and per-capita rates
+
+**Urban Congregations Map** (`/census/viz/urban-congregations/`):
+- Congregation-level point markers in major cities
+- Filterable by denomination family
+- Popup shows congregation name, denomination, membership
+
+**Data Source:**
+- All maps load data from the DRF REST API (`/census/api/`)
+- GeoJSON endpoints for county-level choropleth data
+
+**Success Criteria:**
+- Maps load within 3 seconds on average connection
+- All congregations with `geocode_status = success` appear as markers
+- Maps are usable on mobile (touch zoom, responsive layout)
+
+---
+
+### Feature: REST API
+
+**Description:**
+A publicly accessible read-only REST API exposing the transcribed census data in structured JSON format.
+
+**User Value:**
+Allows researchers to download and analyze the data programmatically without web scraping.
+
+**Functionality:**
+- `GET /census/api/religious-bodies/` — paginated list of all congregations
+- `GET /census/api/religious-bodies/<id>/` — single congregation detail
+- `GET /census/api/denominations/` — denomination reference list
+- Filtering by denomination, county, populated place, geocode status
+- Full-text search on name fields
+- Ordering support
+- 100 records per page; standard `next`/`previous` pagination links
+
+**Edge Cases:**
+- Request for non-existent record: 404 with JSON error
+- Invalid filter parameter: Ignored (Django Filter behavior)
+
+---
+
+### Feature: Content Management (Blog & Visualizations)
+
+**Description:**
+A CMS for publishing scholarly blog posts, static pages, and featured interactive visualizations.
+
+**User Value:**
+Provides a publication venue for the research team's findings, co-located with the data.
+
+**Functionality:**
+
+**Blog Posts:**
+- Markdown content with image support
+- Author attribution, publication date
+- Thumbnail image for listing pages
+- Draft mode (hidden from public until published)
+- Support for embedded Observable Plot interactive visualizations (via ES6 import maps)
+
+**Static Pages:**
+- Markdown + HTML content
+- Optional navigation inclusion with custom label and sort order
+- Scheduled publishing via `publish_date`
+
+**Visualizations:**
+- Featured interactive D3/Observable Plot visualizations
+- Associated JavaScript and CSS files
+- DOI field for scholarly citation
+
+**User Interactions:**
+- Reviewer logs into admin → creates blog post → sets `is_draft=False` → post appears on `/blog/`
+- User visits `/blog/` → sees list of published posts → clicks through to detail
+- Detail page loads Observable Plot visualizations via CDN import maps (no page reload)
+
+---
+
+### Feature: Analytics Dashboard
+
+**Description:**
+An internal reporting interface for the research team to query and analyze the transcribed data.
+
+**User Value:**
+Enables the team to answer research questions about the dataset without writing SQL.
+
+**Functionality:**
+- Query builder for filtering records by multiple criteria simultaneously
+- Denomination analysis: membership statistics by denomination family
+- Location analysis: record and membership distribution by state/county
+- Data completeness report: which fields are missing across what percentage of records
+- Missing place IDs report: schedules that cannot be geo-located
+
+**Current Status:** Views are implemented; expanding as analysis needs grow.
+
+---
+
+## User Flows
+
+### Flow 1: Transcribing a Census Schedule
+
+**Goal:** Student worker completes transcription of an assigned census schedule
+
+**Starting Point:** Transcriber logs into `/admin/`
+
+**Steps:**
+1. Transcriber sees the admin dashboard → sidebar shows "Transcriptions" section
+2. Clicks "Census Schedules" → list view auto-filters to show only assigned records
+3. Selects a record with status `assigned` or `in_progress`
+4. Record detail page opens, showing the original census schedule image
+5. Transcriber fills in `ReligiousBody` inline form: name, denomination, address, membership counts, property values, clergy information
+6. Saves record → status auto-transitions to `in_progress` (if still `assigned`)
+7. When finished, transcriber clicks "Mark as Needs Review" bulk action (or changes status field)
+8. Record status becomes `needs_review`; transcriber can no longer edit it
+
+**Success Outcome:**
+Record has `transcription_status = needs_review` and at least one complete `ReligiousBody` with membership data.
+
+**Error Paths:**
+- Transcriber can't see any records: They are not assigned any; contact PI
+- Record is missing the original image: Note in transcription notes; PI follows up with Omeka
+- Denomination not in dropdown: Transcriber adds note; PI adds new denomination to reference data
+
+---
+
+### Flow 2: Reviewing and Approving Transcriptions
+
+**Goal:** Reviewer checks a completed transcription and approves or returns it
+
+**Starting Point:** Reviewer logs into `/admin/`
+
+**Steps:**
+1. Dashboard shows count of records in `needs_review` status
+2. Reviewer navigates to Census Schedules → filters by status "Needs Review"
+3. Opens a record → compares transcribed data against the original schedule image
+4. If correct: Changes status to `approved` → saves
+5. If needs correction: Changes status back to `in_progress` → adds note in `transcription_notes` → saves
+   - Transcriber will see the record reappear in their list with the reviewer's note
+
+**Success Outcome:**
+Record has `transcription_status = approved`; all data has been verified against source image.
+
+---
+
+### Flow 3: Bulk Assigning Records
+
+**Goal:** PI assigns a batch of unprocessed records to a student worker at the start of a work session
+
+**Starting Point:** PI or Reviewer in Census Schedules admin list
+
+**Steps:**
+1. Filters list by `transcription_status = unassigned` and optionally by state/county/denomination
+2. Selects 10–20 records using checkboxes
+3. Chooses "Bulk Assign" from the actions dropdown → clicks "Go"
+4. Bulk assign form appears with:
+   - Dropdown: Select transcriber (shows Transcribers group members)
+   - Dropdown: Select reviewer (shows Reviewers group members)
+   - Checkbox: Change status to "Assigned"
+5. PI submits → all selected records updated simultaneously
+6. Confirmation message shows count of updated records
+
+**Success Outcome:**
+Selected records have `transcription_status = assigned` and show correct `assigned_transcriber`.
+
+---
+
+### Flow 4: Browsing Census Data (Public)
+
+**Goal:** Historian finds congregation data for a specific city in 1926
+
+**Starting Point:** User visits `https://religiousecologies.org/census/browser/`
+
+**Steps:**
+1. Browser page loads with state dropdown and empty results
+2. User selects "New York" from state dropdown
+3. County dropdown populates; user selects "Kings"
+4. Populated place dropdown populates; user selects "Brooklyn"
+5. Results list shows all congregations in Brooklyn with denomination and member counts
+6. User clicks a congregation name → navigates to detail page
+7. Detail page shows all transcribed fields: address, building value, finances, membership by age/sex, Sunday school, clergy
+
+**Success Outcome:**
+User finds and reads the complete data for a specific congregation in under 60 seconds.
+
+**Error Paths:**
+- Place selected but no records: "No records found for this location" message with suggestion to broaden search
+- Record partially transcribed (status not yet `approved`): Only fully approved records shown in public view
+
+---
+
+## Out of Scope
+
+### Not in Current Version (Future Enhancements)
+
+- **Email notifications**: Automatic emails when a record is assigned or returned for correction — planned but not implemented
+- **Deadline tracking**: Assignment due dates and overdue alerts for transcribers
+- **Student dashboard**: A non-admin view showing a transcriber's personal progress and assigned work queue
+- **Bulk export via UI**: Public bulk download of full dataset as CSV/JSON (currently admin-only via `export_by_location`)
+- **Transcriber performance metrics**: Individual productivity reports (records per week, error rates)
+- **Mobile transcription interface**: The admin is functional on mobile but not optimized for it
+- **Automated geocoding**: Geocoding is a manual/command-driven process; automatic geocoding on save is not implemented
+
+### Explicitly Excluded
+
+- **Real-time collaboration**: Multiple users editing the same record simultaneously is not supported; Django admin is single-user per record
+- **Public user accounts**: The public browser is read-only; public users cannot create accounts or save searches
+- **IE11 support**: Not tested or supported
+- **Offline mode**: No service worker or offline capability
+
+### Out of Project Scope
+
+- **Omeka integration maintenance**: The Omeka instance is maintained separately; this project only reads from its API
+- **Image digitization**: Scanning and uploading census schedules to Omeka is handled outside this system
+- **Denominational history editorial content**: Denomination taxonomy and family classifications are imported from external CSV; editorial decisions about classification belong to the research team's scholarly process
+
+---
+
+## Open Questions
+
+### Data Questions
+
+- **Q:** Should public-facing views show only `approved` records, or also `completed`?
+  - **Context:** `completed` records have been transcribed but not yet reviewed; they may contain errors. Showing them would increase coverage but risk data quality.
+  - **Options:** `approved` only (high quality, lower coverage), `completed` + `approved` (broader but less verified)
+  - **Owner:** PI
+  - **Status:** Open
+
+- **Q:** What is the intended handling of schedules that have no corresponding congregation data (e.g., blank or damaged images)?
+  - **Context:** Some schedule images may be unusable. We need a status for "skip this record."
+  - **Options:** Add a `skipped` status, use `transcription_notes` to mark as skip, add a boolean `is_unusable` field
+  - **Owner:** PI + Eng
+  - **Status:** Open
+
+### Product Questions
+
+- **Q:** Should the public census browser show the original schedule image?
+  - **Context:** Images are stored locally after fetching from Omeka. Showing them to the public would be valuable for scholars, but increases storage/bandwidth and may have rights implications.
+  - **Options:** Yes (link to image), Yes (embed thumbnail), No (staff only)
+  - **Owner:** PI + Legal (rights)
+  - **Status:** Open
+
+- **Q:** What is the target completion date for a fully transcribed, approved dataset?
+  - **Context:** Useful for planning student worker hours, scheduling publication
+  - **Owner:** PI
+  - **Status:** Open
+
+### Technical Questions
+
+- **Q:** Should geocoding be automated on save for new `ReligiousBody` records?
+  - **Context:** Currently a manual/batch process. Auto-geocoding would improve data completeness but adds latency to saves and requires an external geocoding API.
+  - **Options:** Auto-geocode on save (via Celery task), keep manual batch process, add a one-click geocode button in admin
+  - **Owner:** Eng + PI
+  - **Status:** Open
+
+---
+
+*Last Updated: 2026-02-19*
+*This document is maintained for AI agent context and onboarding.*

--- a/census/management/commands/data_reconciliation.py
+++ b/census/management/commands/data_reconciliation.py
@@ -1,0 +1,820 @@
+"""
+Data reconciliation / sanity check command.
+
+Compares data across three systems:
+  1. Omeka API   (https://omeka.religiousecologies.org/api)  — source
+  2. Django DB   (this project)                              — transcription system
+  3. data.chnm.org                                           — published API
+
+Key mappings used for matching:
+  CensusSchedule.resource_id      ↔  Omeka o:id
+  Denomination.denomination_id    ↔  Omeka mare:denominationId  ↔  data.chnm.org denomination_id
+  County.ahcb_id                  ↔  Omeka mare:ahcbCountyId    ↔  data.chnm.org county_ahcb
+  PopulatedPlace.place_id         ↔  data.chnm.org place_id
+
+Output: a timestamped plain-text report written to the reports/ directory.
+
+Usage:
+    uv run python manage.py sanity_check
+    uv run python manage.py sanity_check --output-dir /path/to/dir
+    uv run python manage.py sanity_check --omeka-delay 1.0   # slower / politer
+    uv run python manage.py sanity_check --omeka-per-page 50 # smaller pages
+"""
+
+import json
+import time
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+
+import requests
+from django.core.management.base import BaseCommand
+
+from census.models import CensusSchedule, Denomination, ReligiousBody
+from location.models import County, PopulatedPlace
+
+OMEKA_API = "https://omeka.religiousecologies.org/api"
+DATA_CHNM_API = "https://data.chnm.org"
+OMEKA_SCHEDULE_CLASS_ID = 111  # mare:Schedule resource class
+REPORT_WIDTH = 80
+
+
+class Command(BaseCommand):
+    help = "Reconcile data between Omeka, Django, and data.chnm.org — writes a text report"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--output-dir",
+            type=str,
+            default="reports",
+            help="Directory for the report file (default: reports/)",
+        )
+        parser.add_argument(
+            "--omeka-delay",
+            type=float,
+            default=0.5,
+            help="Seconds between Omeka API page requests (default: 0.5)",
+        )
+        parser.add_argument(
+            "--omeka-per-page",
+            type=int,
+            default=100,
+            help="Items per page when fetching from Omeka (default: 100)",
+        )
+        parser.add_argument(
+            "--save-cache",
+            type=str,
+            default=None,
+            metavar="FILE",
+            help="Save fetched Omeka + chnm data to a JSON file for faster re-runs",
+        )
+        parser.add_argument(
+            "--load-cache",
+            type=str,
+            default=None,
+            metavar="FILE",
+            help="Load previously cached Omeka + chnm data instead of re-fetching",
+        )
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Entry point
+    # ─────────────────────────────────────────────────────────────────────────
+
+    def handle(self, *args, **options):
+        started_at = datetime.now()
+        output_dir = Path(options["output_dir"])
+        output_dir.mkdir(parents=True, exist_ok=True)
+        report_path = output_dir / f"reconciliation_{started_at.strftime('%Y%m%d_%H%M%S')}.txt"
+
+        self.stdout.write(f"Starting reconciliation at {started_at.strftime('%Y-%m-%d %H:%M:%S')}")
+        self.stdout.write(f"Report will be written to: {report_path}")
+        self.stdout.write("")
+
+        cache_file = options.get("load_cache")
+        if cache_file:
+            # ── Load from cache (skip Omeka + chnm fetches) ──────────────────
+            cache_path = Path(cache_file)
+            self.stdout.write(self.style.WARNING(f"Loading cached data from {cache_path} ..."))
+            with open(cache_path) as fh:
+                cached = json.load(fh)
+            omeka_schedules = cached["omeka_schedules"]
+            chnm_data = cached["chnm_data"]
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"  → {len(omeka_schedules):,} Omeka items and chnm data loaded from cache"
+                )
+            )
+        else:
+            # ── Phase 1: Omeka ────────────────────────────────────────────────
+            self._section_header("PHASE 1: Fetching Omeka Schedule items")
+            omeka_schedules = self._fetch_omeka_schedules(
+                delay=options["omeka_delay"],
+                per_page=options["omeka_per_page"],
+            )
+            self.stdout.write(
+                self.style.SUCCESS(f"  → {len(omeka_schedules):,} Omeka schedule items fetched")
+            )
+
+            # ── Phase 3: data.chnm.org ────────────────────────────────────────
+            self.stdout.write("")
+            self._section_header("PHASE 3: Fetching data.chnm.org endpoints")
+            chnm_data = self._fetch_chnm_data()
+
+            # ── Optionally save cache ─────────────────────────────────────────
+            if options.get("save_cache"):
+                save_path = Path(options["save_cache"])
+                self.stdout.write(f"  Saving cache to {save_path} ...")
+                with open(save_path, "w") as fh:
+                    json.dump({"omeka_schedules": omeka_schedules, "chnm_data": chnm_data}, fh)
+                self.stdout.write(self.style.SUCCESS(f"  → Cache saved: {save_path}"))
+
+        # ── Phase 2: Django DB ────────────────────────────────────────────────
+        self.stdout.write("")
+        self._section_header("PHASE 2: Querying Django database")
+        django_data = self._collect_django_data()
+
+        # ── Phase 4: Report ───────────────────────────────────────────────────
+        self.stdout.write("")
+        self._section_header("PHASE 4: Generating report")
+        report = self._generate_report(
+            started_at=started_at,
+            omeka_schedules=omeka_schedules,
+            django_data=django_data,
+            chnm_data=chnm_data,
+        )
+
+        with open(report_path, "w") as fh:
+            fh.write(report)
+
+        elapsed = (datetime.now() - started_at).total_seconds()
+        self.stdout.write("")
+        self.stdout.write(self.style.SUCCESS(f"Done!  Report: {report_path}"))
+        self.stdout.write(f"Total time: {elapsed / 60:.1f} minutes")
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Data collection
+    # ─────────────────────────────────────────────────────────────────────────
+
+    def _fetch_omeka_schedules(self, delay=0.5, per_page=100):
+        """Page through Omeka and return a list of extracted schedule dicts."""
+        url = f"{OMEKA_API}/items"
+        params = {"resource_class_id": OMEKA_SCHEDULE_CLASS_ID, "per_page": per_page, "page": 1}
+        all_items = []
+        page = 1
+
+        while True:
+            params["page"] = page
+            try:
+                self.stdout.write(
+                    f"  Page {page:>4}  ({len(all_items):,} items so far) ...", ending="\r"
+                )
+                resp = requests.get(url, params=params, timeout=30)
+                resp.raise_for_status()
+                items = resp.json()
+
+                if not items:
+                    self.stdout.write("")  # clear the \r line
+                    break
+
+                for item in items:
+                    all_items.append(self._extract_omeka_fields(item))
+
+                page += 1
+                time.sleep(delay)
+
+            except requests.exceptions.RequestException as exc:
+                self.stdout.write("")
+                self.stdout.write(self.style.ERROR(f"  Omeka API error on page {page}: {exc}"))
+                self.stdout.write(
+                    self.style.WARNING("  Continuing with partial data — results may be incomplete.")
+                )
+                break
+
+        self.stdout.write(
+            f"  Fetched {len(all_items):,} items across {page - 1} page(s)"
+        )
+        return all_items
+
+    def _extract_omeka_fields(self, item):
+        """Pull the fields we care about from a raw Omeka item dict."""
+        def val(prop):
+            entries = item.get(prop, [])
+            return entries[0].get("@value") if entries else None
+
+        return {
+            "omeka_id":        item.get("o:id"),
+            "schedule_id":     val("mare:scheduleId"),
+            "denomination_id": val("mare:denominationId"),
+            "ahcb_county_id":  val("mare:ahcbCountyId"),
+            "title":           item.get("o:title", ""),
+            "is_public":       item.get("o:is_public", False),
+        }
+
+    def _collect_django_data(self):
+        """Query the Django ORM and return everything we need for comparison."""
+        self.stdout.write("  Collecting CensusSchedule records ...")
+        schedules = list(
+            CensusSchedule.objects.select_related(
+                "county__state", "populated_place__county"
+            ).values(
+                "id", "resource_id", "schedule_id", "schedule_title",
+                "transcription_status",
+                "county__ahcb_id", "county__name", "county__state__code",
+                "populated_place__id", "populated_place__place_id", "populated_place__name",
+            )
+        )
+        self.stdout.write(f"    {len(schedules):,} CensusSchedule records")
+
+        self.stdout.write("  Collecting Denomination records ...")
+        denominations = list(
+            Denomination.objects.values(
+                "id", "denomination_id", "name", "short_name", "family_census", "family_relec"
+            )
+        )
+        self.stdout.write(f"    {len(denominations):,} Denomination records")
+
+        self.stdout.write("  Collecting County records ...")
+        counties = list(
+            County.objects.select_related("state").values("ahcb_id", "name", "state__code", "state__name")
+        )
+        self.stdout.write(f"    {len(counties):,} County records")
+
+        self.stdout.write("  Collecting PopulatedPlace records ...")
+        populated_places = list(
+            PopulatedPlace.objects.select_related("county__state").values(
+                "id", "place_id", "name", "county__ahcb_id", "county__state__code"
+            )
+        )
+        self.stdout.write(f"    {len(populated_places):,} PopulatedPlace records")
+
+        self.stdout.write("  Collecting ReligiousBody stats ...")
+        from django.db.models import Count as DjCount
+        rb_geocode = dict(
+            ReligiousBody.objects.values_list("geocode_status").annotate(DjCount("id"))
+        )
+        rb_total = ReligiousBody.objects.count()
+        self.stdout.write(f"    {rb_total:,} ReligiousBody records")
+
+        return {
+            "schedules":        schedules,
+            "denominations":    denominations,
+            "counties":         counties,
+            "populated_places": populated_places,
+            "rb_geocode":       rb_geocode,
+            "rb_total":         rb_total,
+        }
+
+    def _fetch_chnm_data(self):
+        """Fetch reference datasets from data.chnm.org."""
+        result = {}
+        endpoints = {
+            "cities":               "/relcensus/cities",
+            "denominations":        "/relcensus/denominations",
+            "denomination_families":"/relcensus/denomination-families",
+        }
+        for key, path in endpoints.items():
+            url = DATA_CHNM_API + path
+            self.stdout.write(f"  Fetching {url} ...")
+            try:
+                resp = requests.get(url, timeout=60)
+                resp.raise_for_status()
+                result[key] = resp.json()
+                count = len(result[key]) if isinstance(result[key], list) else "1 object"
+                self.stdout.write(f"    → {count} items")
+            except Exception as exc:
+                self.stdout.write(self.style.WARNING(f"    Failed: {exc}"))
+                result[key] = [] if key != "denomination_families" else {}
+
+        return result
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Report generation
+    # ─────────────────────────────────────────────────────────────────────────
+
+    def _generate_report(self, started_at, omeka_schedules, django_data, chnm_data):
+        W = REPORT_WIDTH
+        lines = []
+
+        # ── helpers ────────────────────────────────────────────────────────
+        def h1(title):
+            lines.extend(["", "=" * W, title.center(W), "=" * W])
+
+        def h2(title):
+            lines.extend(["", title, "-" * min(len(title), W)])
+
+        def h3(title):
+            lines.extend(["", f"  {title}", f"  {'~' * min(len(title), W - 2)}"])
+
+        def kv(label, value, indent=0):
+            pad = "  " * indent
+            lines.append(f"{pad}{label:<52} {value}")
+
+        def note(text):
+            lines.append(f"  NOTE: {text}")
+
+        def blank():
+            lines.append("")
+
+        # ── Pre-compute sets ────────────────────────────────────────────────
+
+        # Omeka
+        omeka_ids         = {s["omeka_id"] for s in omeka_schedules}
+        omeka_denom_ids   = {s["denomination_id"] for s in omeka_schedules if s["denomination_id"]}
+        omeka_county_ids  = {s["ahcb_county_id"]  for s in omeka_schedules if s["ahcb_county_id"]}
+        omeka_with_county = {s["omeka_id"] for s in omeka_schedules if s["ahcb_county_id"]}
+        omeka_by_id       = {s["omeka_id"]: s for s in omeka_schedules}
+
+        # Django schedules
+        dj_schedules       = django_data["schedules"]
+        dj_resource_ids    = {s["resource_id"] for s in dj_schedules}
+        dj_by_rid          = {s["resource_id"]: s for s in dj_schedules}
+        dj_denom_ids       = {d["denomination_id"] for d in django_data["denominations"] if d["denomination_id"]}
+        dj_county_ahcb_ids = {c["ahcb_id"] for c in django_data["counties"]}
+        dj_place_ids       = {p["place_id"] for p in django_data["populated_places"] if p["place_id"]}
+        dj_with_county     = {s["resource_id"] for s in dj_schedules if s["county__ahcb_id"]}
+        dj_with_place      = {s["resource_id"] for s in dj_schedules if s["populated_place__place_id"]}
+
+        # Status breakdown
+        status_counts = defaultdict(int)
+        for s in dj_schedules:
+            status_counts[s["transcription_status"]] += 1
+
+        # data.chnm.org
+        chnm_cities          = chnm_data.get("cities", [])
+        chnm_denoms          = chnm_data.get("denominations", [])
+        chnm_denom_ids       = {d["denomination_id"] for d in chnm_denoms if d.get("denomination_id")}
+        chnm_place_ids       = {c["place_id"] for c in chnm_cities if c.get("place_id")}
+        chnm_county_ahcb_ids = {c["county_ahcb"] for c in chnm_cities if c.get("county_ahcb")}
+        chnm_place_by_id     = {c["place_id"]: c for c in chnm_cities if c.get("place_id")}
+
+        # Derived sets used in multiple sections
+        in_both                          = omeka_ids & dj_resource_ids
+        in_omeka_not_django              = omeka_ids - dj_resource_ids
+        in_django_not_omeka              = dj_resource_ids - omeka_ids
+        omeka_has_county_in_both         = {oid for oid in in_both if omeka_by_id[oid]["ahcb_county_id"]}
+        dj_missing_county_omeka_has      = omeka_has_county_in_both - dj_with_county
+        denom_in_omeka_not_django        = omeka_denom_ids - dj_denom_ids
+        denom_in_django_not_omeka        = dj_denom_ids - omeka_denom_ids
+        denom_in_omeka_not_chnm          = omeka_denom_ids - chnm_denom_ids
+        denom_in_chnm_not_django         = chnm_denom_ids - dj_denom_ids
+        denom_in_django_not_chnm         = dj_denom_ids - chnm_denom_ids
+        counties_in_omeka_not_django     = omeka_county_ids - dj_county_ahcb_ids
+        places_in_chnm_not_django        = chnm_place_ids - dj_place_ids
+        places_in_django_not_chnm        = dj_place_ids - chnm_place_ids
+        chnm_counties_not_in_django      = chnm_county_ahcb_ids - dj_county_ahcb_ids
+
+        # ── Header ─────────────────────────────────────────────────────────
+        lines.append("=" * W)
+        lines.append("RELIGIOUS ECOLOGIES  —  DATA RECONCILIATION REPORT".center(W))
+        lines.append("=" * W)
+        blank()
+        lines.append(f"  Generated:  {started_at.strftime('%Y-%m-%d %H:%M:%S')}")
+        lines.append(f"  Completed:  {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        lines.append(f"  Sources:    (1) Omeka API   (2) Django DB   (3) data.chnm.org")
+        blank()
+
+        # ── Executive Summary ───────────────────────────────────────────────
+        h1("EXECUTIVE SUMMARY")
+        blank()
+
+        schedule_diff = len(omeka_ids) - len(dj_resource_ids)
+        schedule_ok   = schedule_diff == 0
+        kv("Omeka Schedule items fetched:",        f"{len(omeka_ids):,}")
+        kv("Django CensusSchedule records:",       f"{len(dj_resource_ids):,}")
+        kv("Count match:",                         "YES ✓" if schedule_ok else f"NO ✗  (delta = {schedule_diff:+,})")
+        kv("  In Omeka but not Django:",            f"{len(in_omeka_not_django):,}")
+        kv("  In Django but not Omeka:",            f"{len(in_django_not_omeka):,}")
+        blank()
+
+        pct = lambda n, d: f"{n:,}  ({n/max(d,1)*100:.1f}%)"
+        kv("Schedules w/ county in Omeka (mare:ahcbCountyId):", pct(len(omeka_with_county), len(omeka_ids)))
+        kv("Schedules w/ county in Django (FK set):",           pct(len(dj_with_county),    len(dj_resource_ids)))
+        kv("Django schedules missing county Omeka has:",        f"{len(dj_missing_county_omeka_has):,}")
+        blank()
+        kv("Django schedules with populated_place linked:",     pct(len(dj_with_place), len(dj_resource_ids)))
+        kv("PopulatedPlace records in Django:",                 f"{len(dj_place_ids):,}")
+        kv("Cities in data.chnm.org /relcensus/cities:",        f"{len(chnm_place_ids):,}")
+        kv("  In data.chnm.org but NOT in Django:",             f"{len(places_in_chnm_not_django):,}")
+        kv("  In Django but NOT in data.chnm.org:",             f"{len(places_in_django_not_chnm):,}")
+        blank()
+        kv("Denomination IDs referenced in Omeka schedules:",   f"{len(omeka_denom_ids):,}")
+        kv("Denomination records in Django:",                   f"{len(dj_denom_ids):,}")
+        kv("Denomination records in data.chnm.org:",            f"{len(chnm_denom_ids):,}")
+        kv("  Omeka denom IDs not in Django:",                  f"{len(denom_in_omeka_not_django):,}")
+        kv("  Django denom IDs not in data.chnm.org:",          f"{len(denom_in_django_not_chnm):,}")
+        blank()
+        kv("ReligiousBody total records:",                      f"{django_data['rb_total']:,}")
+        for gs, gc in sorted(django_data["rb_geocode"].items(), key=lambda x: (x[0] is None, x[0] or "")):
+            kv(f"  geocode_status = '{gs}':", f"{gc:,}")
+
+        # ── Section 1: Schedule Counts ──────────────────────────────────────
+        h1("SECTION 1: SCHEDULE COUNTS")
+
+        h2("1.1  Totals")
+        blank()
+        kv("Omeka Schedule items (resource_class_id=111):", f"{len(omeka_ids):,}")
+        kv("Django CensusSchedule records:",                f"{len(dj_resource_ids):,}")
+        kv("Difference (Omeka − Django):",                  f"{schedule_diff:+,}")
+
+        h2("1.2  Transcription Status Breakdown (Django)")
+        blank()
+        ordered_statuses = [
+            "unassigned", "assigned", "in_progress",
+            "needs_review", "completed", "approved",
+        ]
+        for st in ordered_statuses:
+            cnt = status_counts.get(st, 0)
+            kv(f"  {st}:", f"{cnt:>6,}  ({cnt/max(len(dj_resource_ids),1)*100:.1f}%)")
+        for st in sorted(set(status_counts) - set(ordered_statuses)):
+            cnt = status_counts[st]
+            kv(f"  {st} (unexpected):", f"{cnt:>6,}")
+        kv("  TOTAL:", f"{len(dj_resource_ids):>6,}")
+
+        h2("1.3  In Omeka but NOT in Django")
+        blank()
+        kv("Count:", f"{len(in_omeka_not_django):,}")
+        if in_omeka_not_django:
+            blank()
+            lines.append(f"  {'Omeka ID':<10}  {'Schedule ID':<22}  {'Denom ID':<20}  {'County AHCB':<22}  Public")
+            lines.append("  " + "-" * 82)
+            for oid in sorted(in_omeka_not_django):
+                s = omeka_by_id[oid]
+                lines.append(
+                    f"  {oid:<10}  {str(s['schedule_id'] or ''):<22}  "
+                    f"{str(s['denomination_id'] or ''):<20}  "
+                    f"{str(s['ahcb_county_id'] or ''):<22}  "
+                    f"{'Yes' if s['is_public'] else 'No'}"
+                )
+        else:
+            lines.append("  (none — all Omeka schedules have a matching Django record)")
+
+        h2("1.4  In Django but NOT in Omeka")
+        blank()
+        kv("Count:", f"{len(in_django_not_omeka):,}")
+        if in_django_not_omeka:
+            blank()
+            lines.append(f"  {'Resource ID':<12}  {'Schedule Title':<48}  Status")
+            lines.append("  " + "-" * 75)
+            for rid in sorted(in_django_not_omeka):
+                s = dj_by_rid.get(rid, {})
+                title  = (s.get("schedule_title") or "")[:46]
+                status = s.get("transcription_status", "")
+                lines.append(f"  {rid:<12}  {title:<48}  {status}")
+        else:
+            lines.append("  (none — all Django schedules exist in Omeka)")
+
+        # ── Section 2: Denomination Reconciliation ──────────────────────────
+        h1("SECTION 2: DENOMINATION RECONCILIATION")
+
+        h2("2.1  Summary")
+        blank()
+        kv("Denomination IDs in Omeka schedules:",    f"{len(omeka_denom_ids):,}")
+        kv("Denomination records in Django:",         f"{len(dj_denom_ids):,}")
+        kv("Denomination records in data.chnm.org:",  f"{len(chnm_denom_ids):,}")
+        blank()
+        kv("In Omeka but NOT in Django:",             f"{len(denom_in_omeka_not_django):,}")
+        kv("In Django but NOT in Omeka:",             f"{len(denom_in_django_not_omeka):,}")
+        kv("In Omeka but NOT in data.chnm.org:",      f"{len(denom_in_omeka_not_chnm):,}")
+        kv("In data.chnm.org but NOT in Django:",     f"{len(denom_in_chnm_not_django):,}")
+        kv("In Django but NOT in data.chnm.org:",     f"{len(denom_in_django_not_chnm):,}")
+
+        h2("2.2  Denomination IDs in Omeka schedules but NOT in Django")
+        blank()
+        kv("Count:", f"{len(denom_in_omeka_not_django):,}")
+        if denom_in_omeka_not_django:
+            note("These denomination_ids appear on Omeka Schedule items but have no matching")
+            note("Denomination record in Django. Schedules using these IDs may be mis-linked")
+            note("or the denomination import may be incomplete.")
+            blank()
+            omeka_denom_sched_count = defaultdict(int)
+            for s in omeka_schedules:
+                if s["denomination_id"] in denom_in_omeka_not_django:
+                    omeka_denom_sched_count[s["denomination_id"]] += 1
+            lines.append(f"  {'Denomination ID':<28}  Schedules Affected")
+            lines.append("  " + "-" * 50)
+            for did in sorted(denom_in_omeka_not_django):
+                lines.append(f"  {did:<28}  {omeka_denom_sched_count[did]:,}")
+        else:
+            lines.append("  (none — all Omeka denomination IDs exist in Django)")
+
+        h2("2.3  Django Denomination IDs NOT referenced in any Omeka schedule")
+        blank()
+        kv("Count:", f"{len(denom_in_django_not_omeka):,}")
+        if denom_in_django_not_omeka:
+            note("These denominations exist in Django but no Omeka schedule references them.")
+            blank()
+            denom_by_id = {d["denomination_id"]: d for d in django_data["denominations"]}
+            lines.append(f"  {'Denomination ID':<28}  Name")
+            lines.append("  " + "-" * 70)
+            for did in sorted(denom_in_django_not_omeka):
+                d = denom_by_id.get(did, {})
+                lines.append(f"  {did:<28}  {(d.get('name') or '')[:40]}")
+        else:
+            lines.append("  (none — all Django denominations appear in Omeka schedules)")
+
+        h2("2.4  Denomination IDs in data.chnm.org but NOT in Django")
+        blank()
+        kv("Count:", f"{len(denom_in_chnm_not_django):,}")
+        if denom_in_chnm_not_django:
+            chnm_denom_by_id = {d["denomination_id"]: d for d in chnm_denoms if d.get("denomination_id")}
+            lines.append(f"  {'Denomination ID':<28}  Name (data.chnm.org)")
+            lines.append("  " + "-" * 70)
+            for did in sorted(denom_in_chnm_not_django):
+                d = chnm_denom_by_id.get(did, {})
+                lines.append(f"  {did:<28}  {(d.get('name') or '')[:40]}")
+        else:
+            lines.append("  (none)")
+
+        h2("2.5  Django Denomination IDs NOT in data.chnm.org")
+        blank()
+        kv("Count:", f"{len(denom_in_django_not_chnm):,}")
+        if denom_in_django_not_chnm:
+            denom_by_id = {d["denomination_id"]: d for d in django_data["denominations"]}
+            lines.append(f"  {'Denomination ID':<28}  Name (Django)")
+            lines.append("  " + "-" * 70)
+            for did in sorted(denom_in_django_not_chnm):
+                d = denom_by_id.get(did, {})
+                lines.append(f"  {did:<28}  {(d.get('name') or '')[:40]}")
+        else:
+            lines.append("  (none — all Django denominations are in data.chnm.org)")
+
+        h2("2.6  Denomination ID mismatch: Omeka vs data.chnm.org")
+        blank()
+        kv("Count (in Omeka but NOT in data.chnm.org):", f"{len(denom_in_omeka_not_chnm):,}")
+        if denom_in_omeka_not_chnm:
+            for did in sorted(denom_in_omeka_not_chnm):
+                lines.append(f"    - {did}")
+        else:
+            lines.append("  (none)")
+
+        # ── Section 3: County Coverage ──────────────────────────────────────
+        h1("SECTION 3: COUNTY COVERAGE")
+
+        h2("3.1  Coverage Summary")
+        blank()
+        kv("Omeka schedules with mare:ahcbCountyId:",
+           pct(len(omeka_with_county), len(omeka_ids)))
+        kv("Django schedules with county FK set:",
+           pct(len(dj_with_county), len(dj_resource_ids)))
+        kv("Django schedules missing county where Omeka has it:",
+           f"{len(dj_missing_county_omeka_has):,}")
+        blank()
+        kv("Distinct AHCB county IDs in Omeka schedules:",   f"{len(omeka_county_ids):,}")
+        kv("County records in Django:",                      f"{len(dj_county_ahcb_ids):,}")
+        kv("Distinct county_ahcb values in data.chnm.org:",  f"{len(chnm_county_ahcb_ids):,}")
+
+        h2("3.2  County AHCB IDs in Omeka but NOT in Django County table")
+        blank()
+        kv("Count:", f"{len(counties_in_omeka_not_django):,}")
+        if counties_in_omeka_not_django:
+            note("Schedules with these county IDs cannot be linked to a County in Django.")
+            blank()
+            missing_county_sched_count = defaultdict(int)
+            for s in omeka_schedules:
+                if s["ahcb_county_id"] in counties_in_omeka_not_django:
+                    missing_county_sched_count[s["ahcb_county_id"]] += 1
+            lines.append(f"  {'AHCB County ID':<32}  Schedules Affected")
+            lines.append("  " + "-" * 52)
+            for ahcb in sorted(counties_in_omeka_not_django):
+                lines.append(f"  {ahcb:<32}  {missing_county_sched_count[ahcb]:,}")
+        else:
+            lines.append("  (none — all Omeka county IDs exist in Django)")
+
+        h2("3.3  County AHCB IDs in data.chnm.org but NOT in Django County table")
+        blank()
+        kv("Count:", f"{len(chnm_counties_not_in_django):,}")
+        if chnm_counties_not_in_django:
+            for ahcb in sorted(chnm_counties_not_in_django):
+                lines.append(f"    - {ahcb}")
+        else:
+            lines.append("  (none)")
+
+        h2("3.4  Django Schedules Missing County (Where Omeka Has County Data)")
+        blank()
+        kv("Count:", f"{len(dj_missing_county_omeka_has):,}")
+        if dj_missing_county_omeka_has:
+            note("Omeka has a county AHCB ID for these schedules, but the Django county FK")
+            note("is not set. Running `link_counties_from_omeka` should resolve these.")
+            blank()
+            lines.append(
+                f"  {'Omeka ID':<10}  {'Schedule ID':<22}  {'AHCB County (Omeka)':<26}  Django Status"
+            )
+            lines.append("  " + "-" * 80)
+            shown = 0
+            for oid in sorted(dj_missing_county_omeka_has):
+                if shown >= 150:
+                    remaining = len(dj_missing_county_omeka_has) - shown
+                    lines.append(f"  ... {remaining:,} more — see Appendix A for full list")
+                    break
+                s  = omeka_by_id[oid]
+                ds = dj_by_rid.get(oid, {})
+                lines.append(
+                    f"  {oid:<10}  {str(s['schedule_id'] or ''):<22}  "
+                    f"{str(s['ahcb_county_id'] or ''):<26}  "
+                    f"{ds.get('transcription_status', '?')}"
+                )
+                shown += 1
+        else:
+            lines.append("  (none — county linkage is complete for all matched schedules)")
+
+        h2("3.5  County Coverage Breakdown by State (Django schedules)")
+        blank()
+        state_county_counts = defaultdict(lambda: {"with": 0, "without": 0})
+        for s in dj_schedules:
+            state = s.get("county__state__code") or "(unlinked)"
+            if s["county__ahcb_id"]:
+                state_county_counts[state]["with"] += 1
+            else:
+                state_county_counts[state]["without"] += 1
+        lines.append(f"  {'State':<8}  {'W/ County':>9}  {'No County':>9}  {'Total':>7}  {'Coverage':>9}")
+        lines.append("  " + "-" * 52)
+        for state in sorted(state_county_counts):
+            wc    = state_county_counts[state]["with"]
+            nc    = state_county_counts[state]["without"]
+            tot   = wc + nc
+            lines.append(f"  {state:<8}  {wc:>9,}  {nc:>9,}  {tot:>7,}  {wc/max(tot,1)*100:>8.1f}%")
+
+        # ── Section 4: Populated Place Coverage ────────────────────────────
+        h1("SECTION 4: POPULATED PLACE COVERAGE")
+
+        h2("4.1  Coverage Summary")
+        blank()
+        kv("Django schedules with populated_place linked:",
+           pct(len(dj_with_place), len(dj_resource_ids)))
+        kv("PopulatedPlace records in Django:",         f"{len(django_data['populated_places']):,}")
+        kv("  With a place_id value (non-null):",       f"{len(dj_place_ids):,}")
+        kv("  With no place_id (null):",
+           f"{sum(1 for p in django_data['populated_places'] if not p['place_id']):,}")
+        blank()
+        kv("Cities in data.chnm.org /relcensus/cities:",     f"{len(chnm_place_ids):,}")
+        kv("  In data.chnm.org but NOT in Django:",          f"{len(places_in_chnm_not_django):,}")
+        kv("  In Django but NOT in data.chnm.org:",          f"{len(places_in_django_not_chnm):,}")
+
+        h2("4.2  Place IDs in data.chnm.org but NOT in Django PopulatedPlace")
+        blank()
+        kv("Count:", f"{len(places_in_chnm_not_django):,}")
+        if places_in_chnm_not_django:
+            note("These place_ids exist in data.chnm.org but not in Django's PopulatedPlace table.")
+            blank()
+            lines.append(f"  {'Place ID':<12}  {'City':<36}  {'State':<6}  County")
+            lines.append("  " + "-" * 75)
+            shown = 0
+            for pid in sorted(places_in_chnm_not_django):
+                if shown >= 100:
+                    lines.append(f"  ... {len(places_in_chnm_not_django)-shown:,} more — see Appendix B")
+                    break
+                c = chnm_place_by_id.get(pid, {})
+                lines.append(
+                    f"  {pid:<12}  {(c.get('city',''))[:35]:<36}  "
+                    f"{c.get('state',''):<6}  {(c.get('county',''))[:25]}"
+                )
+                shown += 1
+        else:
+            lines.append("  (none — all data.chnm.org cities are in Django)")
+
+        h2("4.3  Place IDs in Django PopulatedPlace but NOT in data.chnm.org")
+        blank()
+        kv("Count:", f"{len(places_in_django_not_chnm):,}")
+        if places_in_django_not_chnm:
+            note("These Django PopulatedPlace records have a place_id not in data.chnm.org.")
+            blank()
+            dj_pp_by_id = {p["place_id"]: p for p in django_data["populated_places"] if p["place_id"]}
+            lines.append(f"  {'Place ID':<12}  {'Name':<36}  {'State':<6}  County AHCB")
+            lines.append("  " + "-" * 75)
+            shown = 0
+            for pid in sorted(places_in_django_not_chnm):
+                if shown >= 100:
+                    lines.append(f"  ... {len(places_in_django_not_chnm)-shown:,} more — see Appendix C")
+                    break
+                p = dj_pp_by_id.get(pid, {})
+                lines.append(
+                    f"  {pid:<12}  {(p.get('name',''))[:35]:<36}  "
+                    f"{p.get('county__state__code',''):<6}  {(p.get('county__ahcb_id',''))[:25]}"
+                )
+                shown += 1
+        else:
+            lines.append("  (none — all Django place_ids are in data.chnm.org)")
+
+        h2("4.4  Populated Place Coverage by State (Django schedules)")
+        blank()
+        state_place_counts = defaultdict(lambda: {"with": 0, "without": 0})
+        for s in dj_schedules:
+            state = s.get("county__state__code") or "(unlinked)"
+            if s["populated_place__place_id"]:
+                state_place_counts[state]["with"] += 1
+            else:
+                state_place_counts[state]["without"] += 1
+        lines.append(f"  {'State':<8}  {'W/ Place':>8}  {'No Place':>8}  {'Total':>7}  {'Coverage':>9}")
+        lines.append("  " + "-" * 50)
+        for state in sorted(state_place_counts):
+            wp  = state_place_counts[state]["with"]
+            np_ = state_place_counts[state]["without"]
+            tot = wp + np_
+            lines.append(
+                f"  {state:<8}  {wp:>8,}  {np_:>8,}  {tot:>7,}  {wp/max(tot,1)*100:>8.1f}%"
+            )
+
+        # ── Section 5: data.chnm.org Cross-Check ───────────────────────────
+        h1("SECTION 5: DATA.CHNM.ORG CROSS-CHECK")
+
+        h2("5.1  Summary")
+        blank()
+        kv("data.chnm.org /relcensus/cities:",               f"{len(chnm_cities):,} records")
+        kv("data.chnm.org /relcensus/denominations:",         f"{len(chnm_denoms):,} records")
+        fam_data = chnm_data.get("denomination_families", {})
+        if isinstance(fam_data, dict):
+            fam_relec  = len(fam_data.get("family_relec", []))
+            fam_census = len(fam_data.get("family_census", []))
+            kv("data.chnm.org /relcensus/denomination-families:",
+               f"{fam_relec} family_relec  /  {fam_census} family_census")
+
+        h2("5.2  Denomination ID alignment across all three systems")
+        blank()
+        all_denom_ids = omeka_denom_ids | dj_denom_ids | chnm_denom_ids
+        lines.append(f"  {'Denomination ID':<28}  Omeka  Django  data.chnm.org")
+        lines.append("  " + "-" * 60)
+        discrepancies = []
+        for did in sorted(all_denom_ids):
+            in_o = "  ✓   " if did in omeka_denom_ids else "  ✗   "
+            in_d = "  ✓   " if did in dj_denom_ids    else "  ✗   "
+            in_c = "      ✓" if did in chnm_denom_ids  else "      ✗"
+            if not (did in omeka_denom_ids and did in dj_denom_ids and did in chnm_denom_ids):
+                discrepancies.append((did, in_o, in_d, in_c))
+        if discrepancies:
+            for did, in_o, in_d, in_c in discrepancies:
+                lines.append(f"  {did:<28} {in_o} {in_d} {in_c}")
+        else:
+            lines.append("  All denomination IDs are consistent across all three systems ✓")
+
+        # ── Appendix A: Full missing-county list ────────────────────────────
+        h1("APPENDIX A: DJANGO SCHEDULES MISSING COUNTY (OMEKA HAS COUNTY DATA)")
+        blank()
+        kv("Total count:", f"{len(dj_missing_county_omeka_has):,}")
+        blank()
+        if dj_missing_county_omeka_has:
+            lines.append(
+                f"  {'Omeka ID':<10}  {'Schedule ID':<24}  {'AHCB County (Omeka)':<28}  Django Status"
+            )
+            lines.append("  " + "-" * 82)
+            for oid in sorted(dj_missing_county_omeka_has):
+                s  = omeka_by_id[oid]
+                ds = dj_by_rid.get(oid, {})
+                lines.append(
+                    f"  {oid:<10}  {str(s['schedule_id'] or ''):<24}  "
+                    f"{str(s['ahcb_county_id'] or ''):<28}  "
+                    f"{ds.get('transcription_status', '?')}"
+                )
+        else:
+            lines.append("  (none)")
+
+        # ── Appendix B: Full places-in-chnm-not-django list ─────────────────
+        h1("APPENDIX B: PLACE IDs IN DATA.CHNM.ORG NOT IN DJANGO")
+        blank()
+        kv("Total count:", f"{len(places_in_chnm_not_django):,}")
+        blank()
+        if places_in_chnm_not_django:
+            lines.append(f"  {'Place ID':<12}  {'City':<36}  {'State':<6}  County")
+            lines.append("  " + "-" * 75)
+            for pid in sorted(places_in_chnm_not_django):
+                c = chnm_place_by_id.get(pid, {})
+                lines.append(
+                    f"  {pid:<12}  {(c.get('city',''))[:35]:<36}  "
+                    f"{c.get('state',''):<6}  {(c.get('county',''))[:28]}"
+                )
+        else:
+            lines.append("  (none)")
+
+        # ── Appendix C: Full places-in-django-not-chnm list ─────────────────
+        h1("APPENDIX C: PLACE IDs IN DJANGO NOT IN DATA.CHNM.ORG")
+        blank()
+        kv("Total count:", f"{len(places_in_django_not_chnm):,}")
+        blank()
+        if places_in_django_not_chnm:
+            dj_pp_by_id = {p["place_id"]: p for p in django_data["populated_places"] if p["place_id"]}
+            lines.append(f"  {'Place ID':<12}  {'Name':<36}  {'State':<6}  County AHCB")
+            lines.append("  " + "-" * 75)
+            for pid in sorted(places_in_django_not_chnm):
+                p = dj_pp_by_id.get(pid, {})
+                lines.append(
+                    f"  {pid:<12}  {(p.get('name',''))[:35]:<36}  "
+                    f"{p.get('county__state__code',''):<6}  {(p.get('county__ahcb_id',''))[:28]}"
+                )
+        else:
+            lines.append("  (none)")
+
+        # ── Footer ──────────────────────────────────────────────────────────
+        blank()
+        lines.append("=" * W)
+        lines.append("END OF REPORT".center(W))
+        lines.append("=" * W)
+
+        return "\n".join(lines) + "\n"
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Utilities
+    # ─────────────────────────────────────────────────────────────────────────
+
+    def _section_header(self, title):
+        self.stdout.write(f"\n{'─' * 60}")
+        self.stdout.write(title)
+        self.stdout.write(f"{'─' * 60}")


### PR DESCRIPTION
**Related issues**: #65 

This PR adds a new data management command for comparing the Omeka API, Apiary, and Django for missing data and generates a plain-text report covering schedule counts, denomination alignment, county coverage, and populated place coverage. Supports `--save-cache` / `--load-cache` to avoid re-crawling Omeka on re-runs. Outputs to a `reports/` directory.