### PR TITLE
feat: Add cache-based syncing to `link_counties_from_omeka`

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -334,6 +334,11 @@ UNFOLD = {
                         "link": lambda request: "/admin/census/religiousbody/",
                     },
                     {
+                        "title": "Denominations",
+                        "icon": "category",
+                        "link": lambda request: "/admin/census/denomination/",
+                    },
+                    {
                         "title": "Membership Data",
                         "icon": "people",
                         "link": lambda request: "/admin/census/membership/",
@@ -350,11 +355,6 @@ UNFOLD = {
                 "separator": True,
                 "collapsible": True,
                 "items": [
-                    {
-                        "title": "Denominations",
-                        "icon": "category",
-                        "link": lambda request: "/admin/census/denomination/",
-                    },
                     {
                         "title": "States",
                         "icon": "flag",

--- a/location/management/commands/link_counties_from_omeka.py
+++ b/location/management/commands/link_counties_from_omeka.py
@@ -9,10 +9,14 @@ This command complements import_transcribed_locations.py by:
 Usage:
     python manage.py link_counties_from_omeka
     python manage.py link_counties_from_omeka --dry-run
+    python manage.py link_counties_from_omeka --load-cache reports/omeka_chnm_cache.json
+    python manage.py link_counties_from_omeka --only-missing
     python manage.py link_counties_from_omeka --limit 10  # For testing
 """
 
+import json
 import time
+from pathlib import Path
 
 import requests
 from django.core.management.base import BaseCommand
@@ -32,16 +36,23 @@ class Command(BaseCommand):
             help="Show what would be updated without making changes",
         )
         parser.add_argument(
+            "--load-cache",
+            type=str,
+            default=None,
+            metavar="FILE",
+            help="Load Omeka data from a cache JSON file (e.g. from data_reconciliation --save-cache) instead of fetching from the API",
+        )
+        parser.add_argument(
             "--limit",
             type=int,
             default=None,
-            help="Limit number of API pages to fetch (for testing)",
+            help="Limit number of API pages to fetch (for testing; ignored with --load-cache)",
         )
         parser.add_argument(
             "--start-page",
             type=int,
             default=1,
-            help="Start from specific page number (useful for resuming)",
+            help="Start from specific page number (useful for resuming; ignored with --load-cache)",
         )
         parser.add_argument(
             "--only-missing",
@@ -51,22 +62,28 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
-        limit = options["limit"]
-        start_page = options["start_page"]
         only_missing = options["only_missing"]
+        cache_file = options.get("load_cache")
 
         if dry_run:
-            self.stdout.write(
-                self.style.WARNING("DRY RUN MODE - No changes will be saved")
-            )
-
-        if start_page > 1:
-            self.stdout.write(self.style.SUCCESS(f"Resuming from page {start_page}"))
-
+            self.stdout.write(self.style.WARNING("DRY RUN MODE - No changes will be saved"))
         if only_missing:
             self.stdout.write("Only updating schedules without counties")
 
-        # Statistics
+        # Pre-load county lookup and schedule lookup into memory for bulk efficiency
+        self.stdout.write("Pre-loading County and CensusSchedule data ...")
+        self.county_by_ahcb = {c.ahcb_id: c for c in County.objects.all()}
+        self.schedule_by_resource_id = {
+            s.resource_id: s
+            for s in CensusSchedule.objects.select_related("county").only(
+                "id", "resource_id", "county_id"
+            )
+        }
+        self.stdout.write(
+            f"  {len(self.county_by_ahcb):,} counties, "
+            f"{len(self.schedule_by_resource_id):,} schedules loaded"
+        )
+
         stats = {
             "total_schedules_fetched": 0,
             "schedules_with_county": 0,
@@ -74,10 +91,96 @@ class Command(BaseCommand):
             "matched_to_county": 0,
             "counties_linked": 0,
             "already_had_county": 0,
+            "county_not_found": 0,
             "errors": 0,
         }
 
-        # Fetch schedule items from Omeka API
+        if cache_file:
+            self._link_from_cache(cache_file, stats, dry_run, only_missing)
+        else:
+            self._link_from_api(options, stats, dry_run, only_missing)
+
+        self.print_summary(stats, dry_run)
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Cache-based path (fast)
+    # ─────────────────────────────────────────────────────────────────────────
+
+    def _link_from_cache(self, cache_file, stats, dry_run, only_missing):
+        """Link counties using pre-fetched Omeka data from a cache JSON file."""
+        cache_path = Path(cache_file)
+        self.stdout.write(self.style.WARNING(f"Loading cache from {cache_path} ..."))
+        with open(cache_path) as fh:
+            cached = json.load(fh)
+
+        omeka_schedules = cached["omeka_schedules"]
+        self.stdout.write(f"  {len(omeka_schedules):,} Omeka schedule items in cache")
+
+        # Collect updates in bulk
+        to_update = []
+        skipped_no_county = 0
+
+        for item in omeka_schedules:
+            stats["total_schedules_fetched"] += 1
+            omeka_id = item.get("omeka_id")
+            ahcb_county_id = item.get("ahcb_county_id")
+
+            if ahcb_county_id:
+                stats["schedules_with_county"] += 1
+            else:
+                skipped_no_county += 1
+                continue
+
+            # Match to CensusSchedule by resource_id (direct, reliable)
+            schedule = self.schedule_by_resource_id.get(omeka_id)
+            if not schedule:
+                continue
+            stats["matched_to_census_schedule"] += 1
+
+            # Skip if already has county and --only-missing
+            if only_missing and schedule.county_id:
+                stats["already_had_county"] += 1
+                continue
+
+            # Match county
+            county = self.county_by_ahcb.get(ahcb_county_id)
+            if not county:
+                stats["county_not_found"] += 1
+                continue
+            stats["matched_to_county"] += 1
+
+            # Skip if county is already correct
+            if schedule.county_id == county.id:
+                stats["already_had_county"] += 1
+                continue
+
+            schedule.county = county
+            to_update.append(schedule)
+            stats["counties_linked"] += 1
+
+        self.stdout.write(
+            f"  {skipped_no_county:,} schedules had no county in Omeka (skipped)"
+        )
+        self.stdout.write(f"  {len(to_update):,} schedules to update")
+
+        if not dry_run and to_update:
+            self.stdout.write("  Writing updates ...")
+            with transaction.atomic():
+                CensusSchedule.objects.bulk_update(to_update, ["county"], batch_size=500)
+            self.stdout.write(self.style.SUCCESS(f"  Done — {len(to_update):,} records updated"))
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # API-based path (original behaviour)
+    # ─────────────────────────────────────────────────────────────────────────
+
+    def _link_from_api(self, options, stats, dry_run, only_missing):
+        """Link counties by paging through the Omeka API."""
+        limit = options["limit"]
+        start_page = options["start_page"]
+
+        if start_page > 1:
+            self.stdout.write(self.style.SUCCESS(f"Resuming from page {start_page}"))
+
         base_url = "https://omeka.religiousecologies.org/api/items"
         params = {
             "resource_class_id": 111,  # mare:Schedule resource class
@@ -103,17 +206,11 @@ class Command(BaseCommand):
 
                 stats["total_schedules_fetched"] += len(items)
 
-                # Process each schedule item
                 for item in items:
-                    self.process_schedule_item(
-                        item, stats, dry_run, only_missing=only_missing
-                    )
+                    self._process_api_item(item, stats, dry_run, only_missing)
 
-                # Move to next page
                 params["page"] += 1
                 page_count += 1
-
-                # Be nice to the API
                 time.sleep(0.5)
 
             except requests.exceptions.RequestException as e:
@@ -125,89 +222,58 @@ class Command(BaseCommand):
                 stats["errors"] += 1
                 break
 
-        # Print summary
-        self.print_summary(stats, dry_run)
-
-    def process_schedule_item(self, item, stats, dry_run, only_missing=False):
-        """Process a single schedule item from Omeka API"""
+    def _process_api_item(self, item, stats, dry_run, only_missing):
+        """Process a single raw Omeka API item."""
         try:
-            # Extract schedule_id, denomination_id, and ahcb_county_id
-            schedule_id = self.get_omeka_value(item, "mare:scheduleId")
-            denomination_id = self.get_omeka_value(item, "mare:denominationId")
-            ahcb_county_id = self.get_omeka_value(item, "mare:ahcbCountyId")
-
-            if not schedule_id or not denomination_id:
-                return
+            omeka_id = item.get("o:id")
+            ahcb_county_id = self._get_omeka_value(item, "mare:ahcbCountyId")
 
             if ahcb_county_id:
                 stats["schedules_with_county"] += 1
 
-            # Match to Django Denomination first
-            try:
-                denomination = Denomination.objects.get(denomination_id=denomination_id)
-            except Denomination.DoesNotExist:
-                return
-            except Denomination.MultipleObjectsReturned:
-                self.stdout.write(
-                    self.style.WARNING(
-                        f"Multiple Denomination records for denomination_id {denomination_id}"
-                    )
-                )
-                stats["errors"] += 1
-                return
+            # Match to CensusSchedule by resource_id
+            schedule = self.schedule_by_resource_id.get(omeka_id)
+            if not schedule:
+                # Fallback: match by schedule_title (legacy behaviour)
+                schedule_id = self._get_omeka_value(item, "mare:scheduleId")
+                denomination_id = self._get_omeka_value(item, "mare:denominationId")
+                if not schedule_id or not denomination_id:
+                    return
+                try:
+                    denomination = Denomination.objects.get(denomination_id=denomination_id)
+                    schedule_title = f"{denomination.name}: {schedule_id}"
+                    schedule = CensusSchedule.objects.get(schedule_title=schedule_title)
+                except (Denomination.DoesNotExist, CensusSchedule.DoesNotExist,
+                        CensusSchedule.MultipleObjectsReturned):
+                    return
+            stats["matched_to_census_schedule"] += 1
 
-            # Match to Django CensusSchedule using schedule_id + denomination
-            try:
-                schedule_title = f"{denomination.name}: {schedule_id}"
-                census_schedule = CensusSchedule.objects.get(
-                    schedule_title=schedule_title
-                )
-                stats["matched_to_census_schedule"] += 1
-            except CensusSchedule.DoesNotExist:
-                return
-            except CensusSchedule.MultipleObjectsReturned:
-                self.stdout.write(
-                    self.style.WARNING(
-                        f"Multiple CensusSchedule records for {schedule_title}"
-                    )
-                )
-                stats["errors"] += 1
-                return
-
-            # Check if we should skip (if only_missing and already has county)
-            if only_missing and census_schedule.county:
+            if only_missing and schedule.county_id:
                 stats["already_had_county"] += 1
                 return
 
-            # Match to Django County by AHCB ID
-            if ahcb_county_id:
-                try:
-                    county = County.objects.filter(ahcb_id=ahcb_county_id).first()
-                    if county:
-                        stats["matched_to_county"] += 1
+            if not ahcb_county_id:
+                return
 
-                        # Update the CensusSchedule
-                        if not dry_run:
-                            with transaction.atomic():
-                                census_schedule.county = county
-                                census_schedule.save(update_fields=["county"])
+            county = self.county_by_ahcb.get(ahcb_county_id)
+            if not county:
+                stats["county_not_found"] += 1
+                self.stdout.write(
+                    self.style.WARNING(f"  County not found for AHCB ID: {ahcb_county_id}")
+                )
+                return
+            stats["matched_to_county"] += 1
 
-                        stats["counties_linked"] += 1
-                        self.stdout.write(
-                            f"  Linked schedule {schedule_id} to {county}"
-                        )
-                    else:
-                        self.stdout.write(
-                            self.style.WARNING(
-                                f"  County not found for AHCB ID: {ahcb_county_id}"
-                            )
-                        )
-                except Exception as e:
-                    self.stdout.write(
-                        self.style.WARNING(
-                            f"Error finding county for {ahcb_county_id}: {e}"
-                        )
-                    )
+            if schedule.county_id == county.id:
+                stats["already_had_county"] += 1
+                return
+
+            if not dry_run:
+                with transaction.atomic():
+                    schedule.county = county
+                    schedule.save(update_fields=["county"])
+
+            stats["counties_linked"] += 1
 
         except Exception as e:
             self.stdout.write(
@@ -215,34 +281,26 @@ class Command(BaseCommand):
             )
             stats["errors"] += 1
 
-    def get_omeka_value(self, item, property_name):
-        """Extract a literal value from Omeka API response"""
+    def _get_omeka_value(self, item, property_name):
+        """Extract a literal value from a raw Omeka API response item."""
         values = item.get(property_name, [])
-        if values and len(values) > 0:
-            return values[0].get("@value")
-        return None
+        return values[0].get("@value") if values else None
 
     def print_summary(self, stats, dry_run):
-        """Print summary statistics"""
         self.stdout.write("\n" + "=" * 70)
         self.stdout.write(self.style.SUCCESS("SUMMARY"))
         self.stdout.write("=" * 70)
-        self.stdout.write(
-            f"Total schedules fetched: {stats['total_schedules_fetched']}"
-        )
-        self.stdout.write(
-            f"Schedules with county data: {stats['schedules_with_county']}"
-        )
-        self.stdout.write(
-            f"Matched to CensusSchedule: {stats['matched_to_census_schedule']}"
-        )
-        self.stdout.write(f"Matched to County: {stats['matched_to_county']}")
-        self.stdout.write(f"Counties linked: {stats['counties_linked']}")
+        self.stdout.write(f"Total schedules fetched:      {stats['total_schedules_fetched']:,}")
+        self.stdout.write(f"Schedules with county data:   {stats['schedules_with_county']:,}")
+        self.stdout.write(f"Matched to CensusSchedule:    {stats['matched_to_census_schedule']:,}")
+        self.stdout.write(f"Matched to County:            {stats['matched_to_county']:,}")
+        self.stdout.write(f"Counties linked:              {stats['counties_linked']:,}")
         if stats["already_had_county"] > 0:
-            self.stdout.write(f"Already had county: {stats['already_had_county']}")
-        self.stdout.write(f"Errors: {stats['errors']}")
-
-        if dry_run:
+            self.stdout.write(f"Already had county (skipped): {stats['already_had_county']:,}")
+        if stats["county_not_found"] > 0:
             self.stdout.write(
-                self.style.WARNING("\nDRY RUN - No changes were actually saved")
+                self.style.WARNING(f"County AHCB ID not found:     {stats['county_not_found']:,}")
             )
+        self.stdout.write(f"Errors:                       {stats['errors']:,}")
+        if dry_run:
+            self.stdout.write(self.style.WARNING("\nDRY RUN - No changes were actually saved"))


### PR DESCRIPTION
This pull request adds improvements to the `link_counties_from_omeka` management command, introducing a new cache-based workflow for faster data linking, optimizing lookups, and refactoring the code for clarity and efficiency. It also makes a minor adjustment to the admin menu configuration.

**Enhancements to the Omeka county linking command:**

* Added support for loading Omeka data from a cache JSON file via the new `--load-cache` argument, enabling much faster bulk processing without repeated API calls [[1]](diffhunk://#diff-90391343c0f2c82739db16e533a674b85276750c56c8997a318dbfe3f33aedbeR12-R19) [[2]](diffhunk://#diff-90391343c0f2c82739db16e533a674b85276750c56c8997a318dbfe3f33aedbeR38-R55) [[3]](diffhunk://#diff-90391343c0f2c82739db16e533a674b85276750c56c8997a318dbfe3f33aedbeL54-R183).
* Refactored the command to pre-load all `County` and `CensusSchedule` records into memory for efficient lookups, reducing database queries and improving performance.
* Split the logic into separate methods for cache-based and API-based workflows, and improved statistics reporting with more detailed summary output [[1]](diffhunk://#diff-90391343c0f2c82739db16e533a674b85276750c56c8997a318dbfe3f33aedbeL54-R183) [[2]](diffhunk://#diff-90391343c0f2c82739db16e533a674b85276750c56c8997a318dbfe3f33aedbeL106-L116) [[3]](diffhunk://#diff-90391343c0f2c82739db16e533a674b85276750c56c8997a318dbfe3f33aedbeL128-R306).
* Improved the fallback matching logic when direct resource ID matches fail, and enhanced error handling and reporting for unmatched counties and schedules.

**Admin menu configuration update:**

* Moved the "Denominations" menu item in `config/settings.py` to a higher-level position for better visibility in the admin interface [[1]](diffhunk://#diff-935426a2f59d34e9506987404f8d78b5b5b43431694101f5be37ad65af4cf193R336-R340) [[2]](diffhunk://#diff-935426a2f59d34e9506987404f8d78b5b5b43431694101f5be37ad65af4cf193L353-L357).