### PR TITLE
fix(admin): handle NA values in denomination CSV import

### DIFF
--- a/census/resources.py
+++ b/census/resources.py
@@ -139,6 +139,14 @@ class DenominationResource(resources.ModelResource):
         readonly=True,
     )
 
+    def before_import_row(self, row, **kwargs):
+        """Convert NA or empty published_churches_count to None."""
+        val = row.get("published_churches_count", "")
+        if isinstance(val, str):
+            val = val.strip()
+        if not val or val == "NA":
+            row["published_churches_count"] = None
+
     class Meta:
         model = Denomination
         import_id_fields = ["denomination_id"]


### PR DESCRIPTION
The published_churches_count column can contain 'NA' for denominations without published data (e.g., Universal Brotherhood and Theosophical Society), which caused a decimal.ConversionSyntax error during import. Convert NA/empty values to None before import.