### PR TITLE
Transcription progress table improvements and admin fixes

### DIFF
--- a/analytics/views.py
+++ b/analytics/views.py
@@ -307,7 +307,7 @@ def transcription_progress(request):
                 Subquery(located_count, output_field=IntegerField()), 0
             ),
         )
-        .filter(published_churches_count__isnull=False, published_churches_count__gt=0)
+        .filter(family_relec__isnull=False)
         .order_by("family_relec", "name")
     )
 

--- a/census/admin.py
+++ b/census/admin.py
@@ -103,12 +103,12 @@ class TranscriptionWorkflowFilter(admin.SimpleListFilter):
 
     def lookups(self, request, model_admin):
         return (
-            ("unassigned", "📝 Unassigned Records"),
-            ("assigned_to_me", "👤 Assigned to Me"),
-            ("needs_review", "👀 Needs Review"),
-            ("in_progress", "🔄 In Progress"),
-            ("completed", "✅ Completed"),
-            ("approved", "🎯 Approved"),
+            ("unassigned", "Unassigned Records"),
+            ("assigned_to_me", "Assigned to Me"),
+            ("needs_review", "Needs Review"),
+            ("in_progress", "In Progress"),
+            ("completed", "Completed"),
+            ("approved", "Approved"),
         )
 
     def queryset(self, request, queryset):
@@ -351,13 +351,13 @@ class DenominationAdmin(ImportExportModelAdmin, ModelAdmin):
     list_display = [
         "name",
         "denomination_id",
-        "family_census",
         "family_relec",
+        "family_census",
         "published_churches_count",
     ]
-    search_fields = ["name", "denomination_id", "family_census", "family_relec"]
+    search_fields = ["name", "short_name", "denomination_id", "family_relec", "family_census"]
     ordering = ["name"]
-    list_filter = ["family_census", "family_relec"]
+    list_filter = ["family_relec", "family_census"]
     actions = [sync_denominations]
     inlines = [DenominationCensusReportInline]
 
@@ -562,8 +562,17 @@ class CensusScheduleAdmin(ModelAdmin):
         "resource_id",
         "county__name",
         "county__state__name",
+        "county__state__code",
         "populated_place__name",
         "schedule_denomination__name",
+        "schedule_denomination__short_name",
+        "assigned_transcriber__username",
+        "assigned_transcriber__first_name",
+        "assigned_transcriber__last_name",
+        "assigned_reviewer__username",
+        "assigned_reviewer__first_name",
+        "assigned_reviewer__last_name",
+        "transcription_notes",
     ]
     list_filter = [
         TranscriptionWorkflowFilter,
@@ -1187,7 +1196,18 @@ class ReligiousBodyAdmin(ModelAdmin):
         "denomination",
         "census_record__county__state",
     ]
-    search_fields = ["name", "denomination__name", "census_record__schedule_title"]
+    search_fields = [
+        "name",
+        "address",
+        "denomination__name",
+        "denomination__short_name",
+        "census_record__schedule_title",
+        "census_record__schedule_id",
+        "census_record__county__name",
+        "census_record__county__state__name",
+        "census_record__county__state__code",
+        "census_record__populated_place__name",
+    ]
     autocomplete_fields = ["denomination", "census_record"]
 
     readonly_fields = [
@@ -1387,7 +1407,7 @@ class MembershipAdmin(ModelAdmin):
         elif obj.geocode_status == "failed":
             return "✗ Failed"
         elif obj.geocode_status == "pending":
-            return "⏳ Pending"
+            return "Pending"
         elif obj.geocode_status == "skipped":
             return "− Skipped"
         return "− Not Attempted"

--- a/census/management/commands/import_denominations.py
+++ b/census/management/commands/import_denominations.py
@@ -25,11 +25,18 @@ class Command(BaseCommand):
             action="store_true",
             help="Clear all existing denominations before import",
         )
+        parser.add_argument(
+            "--year",
+            type=int,
+            default=None,
+            help="Only import denominations for this census year (e.g. 1926)",
+        )
 
     def handle(self, *args, **options):
         csv_file = options["csv_file"]
         batch_size = options["batch_size"]
         clear_existing = options["clear_existing"]
+        year_filter = options["year"]
 
         if not os.path.exists(csv_file):
             raise CommandError(f'File "{csv_file}" does not exist.')
@@ -62,21 +69,32 @@ class Command(BaseCommand):
                 reader, start=2
             ):  # Start at 2 because row 1 is headers
                 try:
-                    # Skip rows with empty denomination_id or name
-                    if not row["denomination_id"] or not row["name"]:
+                    # Skip rows that don't match the year filter
+                    if year_filter and row.get("year"):
+                        try:
+                            if int(row["year"]) != year_filter:
+                                continue
+                        except ValueError:
+                            pass
+
+                    # Skip rows with empty name
+                    if not row["name"]:
                         self.stdout.write(
                             self.style.WARNING(
-                                f"Row {row_num}: Skipping - missing denomination_id or name"
+                                f"Row {row_num}: Skipping - missing name"
                             )
                         )
                         skipped_count += 1
                         continue
 
+                    raw_denom_id = row.get("denomination_id", "").strip()
+                    denomination_id = raw_denom_id if raw_denom_id else None
+
                     # Check field lengths
-                    if len(row["denomination_id"]) > 50:
+                    if denomination_id and len(denomination_id) > 50:
                         self.stdout.write(
                             self.style.WARNING(
-                                f"Row {row_num}: Skipping - denomination_id too long ({len(row['denomination_id'])} chars)"
+                                f"Row {row_num}: Skipping - denomination_id too long ({len(denomination_id)} chars)"
                             )
                         )
                         skipped_count += 1
@@ -96,22 +114,33 @@ class Command(BaseCommand):
                     family_census = row.get("family_census", "").strip() or None
                     family_relec = row.get("family_relec", "").strip() or None
 
-                    # Check if denomination exists
+                    # Check if denomination exists — match by denomination_id if
+                    # available, otherwise fall back to matching by name
+                    denomination = None
                     try:
-                        denomination = Denomination.objects.get(
-                            denomination_id=row["denomination_id"]
-                        )
+                        if denomination_id:
+                            denomination = Denomination.objects.get(
+                                denomination_id=denomination_id
+                            )
+                        else:
+                            denomination = Denomination.objects.get(
+                                name=row["name"]
+                            )
+                    except Denomination.DoesNotExist:
+                        pass
+
+                    if denomination:
                         # Update existing
                         denomination.name = row["name"]
+                        denomination.denomination_id = denomination_id
                         denomination.short_name = short_name
                         denomination.family_census = family_census
                         denomination.family_relec = family_relec
                         denominations_to_update.append(denomination)
-
-                    except Denomination.DoesNotExist:
+                    else:
                         # Create new
                         denomination = Denomination(
-                            denomination_id=row["denomination_id"],
+                            denomination_id=denomination_id,
                             name=row["name"],
                             short_name=short_name,
                             family_census=family_census,
@@ -136,6 +165,7 @@ class Command(BaseCommand):
                                 Denomination.objects.bulk_update(
                                     denominations_to_update,
                                     [
+                                        "denomination_id",
                                         "name",
                                         "short_name",
                                         "family_census",
@@ -164,7 +194,7 @@ class Command(BaseCommand):
                 if denominations_to_update:
                     Denomination.objects.bulk_update(
                         denominations_to_update,
-                        ["name", "short_name", "family_census", "family_relec"],
+                        ["denomination_id", "name", "short_name", "family_census", "family_relec"],
                     )
                     updated_count += len(denominations_to_update)
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,183 @@
+# Religious Ecologies Project
+# ==========================
+
+# Show available commands
+default:
+    @just --list
+
+# Development Commands
+# ====================
+
+# Start the Django development server
+preview:
+    uv run python manage.py runserver
+
+# Check for any issues with the Django configuration
+check:
+    uv run python manage.py check
+
+# Open Django shell for interactive debugging
+shell:
+    uv run python manage.py shell
+
+# Database Management
+# ===================
+
+# Create new migration files based on model changes
+mm:
+    uv run python manage.py makemigrations
+
+# Apply migrations to the database
+migrate:
+    uv run python manage.py migrate
+
+# Show migration status
+show-migrations:
+    uv run python manage.py showmigrations
+
+# Create database backup (SQL dump)
+backup-db:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Creating database backup..."
+    mkdir -p backups
+    uv run python -c "
+    from django.conf import settings
+    import os
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+    import django; django.setup()
+    db = settings.DATABASES['default']
+    print(f\"pg_dump -h {db['HOST']} -p {db['PORT']} -U {db['USER']} -d {db['NAME']}\")
+    " | sh > "backups/backup_$(date +%Y%m%d_%H%M%S).sql"
+    echo "Database backup created in backups/ directory"
+
+# Restore database from backup file
+restore-db backup_file:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -f "backups/{{ backup_file }}" ]; then
+        echo "Error: Backup file backups/{{ backup_file }} not found!"
+        ls -la backups/*.sql 2>/dev/null || echo "No backups found."
+        exit 1
+    fi
+    echo "WARNING: This will replace all current database data with backup data!"
+    read -p "Are you sure? Type 'yes' to continue: " confirm
+    [ "$confirm" = "yes" ] || exit 1
+    echo "Restoring database from backups/{{ backup_file }}..."
+    uv run python -c "
+    from django.conf import settings
+    import os
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+    import django; django.setup()
+    db = settings.DATABASES['default']
+    print(f\"psql -h {db['HOST']} -p {db['PORT']} -U {db['USER']} -d {db['NAME']} < backups/{{ backup_file }}\")
+    " | sh
+    echo "Database restored successfully from backups/{{ backup_file }}"
+
+# List available database backups
+list-backups:
+    @ls -la backups/*.sql 2>/dev/null || echo "No backups found in backups/ directory"
+
+# Database Reset & Cleanup
+# ========================
+
+# Clear all data from database (WARNING: DESTRUCTIVE)
+[confirm("This will delete all database data. Continue?")]
+clean-db:
+    uv run python manage.py flush --noinput
+    @echo "Database cleared. Run 'just setup-fresh-db' to recreate with migrations."
+
+# Reset database and apply all migrations from scratch
+[confirm("This will delete all database data and re-migrate. Continue?")]
+reset-db: clean-db
+    uv run python manage.py migrate
+    @echo "Fresh database created with all migrations applied."
+
+# Create a complete fresh database with all setup
+setup-fresh-db: reset-db
+    uv run python manage.py setup_transcription_groups
+    @echo "Fresh database ready with user groups configured."
+
+# Data Import Pipeline
+# ====================
+#
+# IMPORTANT: Data importing must proceed in this exact order:
+#   1. import-locations (location data from CSV)
+#   2. import-denoms (denomination data from CSV)
+#   3. import-omeka (Omeka/DataScribe census data)
+#   4. import-images (Omeka/DataScribe image paths)
+#   5. fetch-images (download actual images)
+#   6. setup-groups (user permissions)
+
+# Import location data from CSV
+import-locations:
+    uv run python manage.py import_locations static-data/popplaces_1926.csv --clear-existing
+
+# Import denomination data from CSV
+import-denoms:
+    uv run python manage.py import_denominations static-data/denominations.csv --year 1926
+
+# Import census schedule data from DataScribe CSV
+import-omeka:
+    uv run python manage.py import_datascribe_data --csv_file="static-data/schedules_with_datascribe.csv"
+
+# Import image paths for census schedules
+import-images:
+    uv run python manage.py import_image_path --csv_file="static-data/schedules.csv"
+
+# Fetch actual images from Omeka API
+fetch-images:
+    uv run python manage.py fetch_omeka_images
+
+# Import denomination census report PDFs from Omeka
+import-denom-pdfs:
+    uv run python manage.py import_denomination_pdfs
+
+# Setup user groups and permissions for transcription workflow
+setup-groups:
+    uv run python manage.py setup_transcription_groups
+
+# Run the complete data import pipeline
+import-all: import-locations import-denoms import-omeka import-images setup-groups
+    @echo "Complete data import pipeline finished. Now run 'just fetch-images' to pull images from Omeka."
+
+# Fresh Start (Complete Reset)
+# ============================
+
+# Complete fresh start: reset database and import all data
+fresh-start: setup-fresh-db import-all
+    @echo "Fresh installation complete with all data imported."
+
+# Frontend Assets
+# ===============
+
+# Build Tailwind CSS for production (one-time build)
+build-css:
+    cd theme/static_src && npm run build
+
+# Watch Tailwind CSS for development (auto-rebuild on changes)
+watch-css:
+    cd theme/static_src && npm run dev
+
+# Utility Commands
+# ================
+
+# Create a superuser account
+superuser:
+    uv run python manage.py createsuperuser
+
+# Collect static files (for production)
+collectstatic:
+    uv run python manage.py collectstatic --noinput
+
+# Run tests
+test *args:
+    uv run pytest {{ args }}
+
+# Format code with black
+fmt:
+    uv run black .
+
+# Format HTML templates with djhtml
+fmt-html:
+    uv run djhtml templates/

--- a/location/admin.py
+++ b/location/admin.py
@@ -24,7 +24,7 @@ class CountyAdmin(ModelAdmin):
 class PopulatedPlaceAdmin(ModelAdmin):
     list_display = ["name", "county", "get_state", "lat", "lon"]
     list_filter = ["county__state"]
-    search_fields = ["name", "county__name", "county__state__name"]
+    search_fields = ["name", "place_id", "county__name", "county__state__name", "county__state__code"]
     ordering = ["county__state", "county", "name"]
     autocomplete_fields = ["county"]
     list_per_page = 50

--- a/static/css/custom_unfold.css
+++ b/static/css/custom_unfold.css
@@ -272,7 +272,6 @@ a.deletelink:hover,
 .search-icon,
 button[type="submit"] .material-symbols-outlined,
 .input-group button[type="submit"],
-form button[type="submit"]:has(.material-symbols-outlined),
 [class*="search"] button {
   background: transparent;
   border: none;

--- a/templates/analytics/transcription_progress.html
+++ b/templates/analytics/transcription_progress.html
@@ -101,7 +101,10 @@
                                 {% for denom in family.denominations %}
                                     <tr class="hover:bg-gray-50">
                                         <td class="px-4 py-3 text-sm text-content-primary pl-8">
-                                            {{ denom.name }}
+                                            <a href="{% url 'admin:census_censusschedule_changelist' %}?schedule_denomination__id__exact={{ denom.pk }}"
+                                               class="text-religious-primary hover:text-primary-700 hover:underline">
+                                                {{ denom.name }}
+                                            </a>
                                         </td>
                                         <td class="px-4 py-3 text-sm text-right text-content-secondary font-mono">
                                             {{ denom.published_churches_count|default:"0"|intcomma }}


### PR DESCRIPTION
## Summary

- **Link denomination names** in the transcription progress table to the admin CensusSchedule changelist filtered by that denomination, for quick drill-down (closes #87)
- **Include all denominations** (even those with zero records like Jewish Congregations) in the progress table by filtering on `family_relec` instead of `published_churches_count > 0` (closes #88)
- **Fix denomination CSV import** to handle rows without a `denomination_id` (6 denominations were being silently skipped); add `--year` flag
- **Fix admin login button** hidden by overly broad CSS selector in `custom_unfold.css`
- **Improve admin search** across CensusSchedule, ReligiousBody, Denomination, and PopulatedPlace (state codes, short names, transcriber/reviewer names, addresses)
- **Reorder denomination filters** so RelEc family comes before census family; remove emojis from workflow filter labels
- **Add justfile** as a replacement for the Makefile

## Post-deploy step

Run the denomination import to pick up the 6 previously skipped denominations:

```bash
uv run python manage.py import_denominations static-data/denominations.csv --year 1926
```

## Test plan

- [x] Verify transcription progress table shows denominations with zero records (e.g., Jewish Congregations)
- [x] Verify denomination names link to filtered admin changelist
- [x] Verify admin login button is visible
- [x] Test admin search on CensusSchedule by state code, transcriber name, denomination short name
- [x] Run `import_denominations` with `--year 1926` and confirm 6 new denominations are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)