### PR TITLE
WCAG accessibility audit fixes, sitemap, footer and home page redesign

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -60,6 +60,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.humanize",
+    "django.contrib.sitemaps",
     "django.forms",
     # model viz
     "django_dbml",

--- a/config/sitemaps.py
+++ b/config/sitemaps.py
@@ -1,0 +1,110 @@
+from django.contrib.sitemaps import Sitemap
+from django.urls import reverse
+
+from census.models import CensusSchedule
+from location.models import State
+from pages.models import BlogPost, Page, Visualization
+
+
+class StaticViewSitemap(Sitemap):
+    """Static pages: home, census browser, maps, browse indexes."""
+
+    changefreq = "weekly"
+    priority = 0.8
+
+    def items(self):
+        return [
+            "index",
+            "census_browser",
+            "denomination_map",
+            "demographics_map",
+            "denominations_browse",
+            "locations_browse",
+            "urban_congregations_map",
+            "api_documentation",
+            "blog-list",
+            "visualization-list",
+        ]
+
+    def location(self, item):
+        return reverse(item)
+
+
+class PageSitemap(Sitemap):
+    """Published CMS pages."""
+
+    changefreq = "monthly"
+    priority = 0.6
+
+    def items(self):
+        return Page.objects.filter(is_published=True)
+
+    def location(self, obj):
+        return reverse("page_detail", kwargs={"slug": obj.slug})
+
+    def lastmod(self, obj):
+        return obj.updated_at
+
+
+class BlogPostSitemap(Sitemap):
+    """Published blog posts."""
+
+    changefreq = "monthly"
+    priority = 0.7
+
+    def items(self):
+        return BlogPost.objects.filter(is_draft=False)
+
+    def location(self, obj):
+        return reverse("blog-detail", kwargs={"slug": obj.slug})
+
+    def lastmod(self, obj):
+        return obj.updated_at
+
+
+class VisualizationSitemap(Sitemap):
+    """Published visualizations."""
+
+    changefreq = "monthly"
+    priority = 0.7
+
+    def items(self):
+        return Visualization.objects.all()
+
+    def location(self, obj):
+        return reverse("visualization-detail", kwargs={"slug": obj.slug})
+
+    def lastmod(self, obj):
+        return obj.updated_at
+
+
+class CensusBrowserStateSitemap(Sitemap):
+    """Census browser state-level pages."""
+
+    changefreq = "weekly"
+    priority = 0.5
+
+    def items(self):
+        return State.objects.all()
+
+    def location(self, obj):
+        return reverse("census_browser_state", kwargs={"state_code": obj.code})
+
+
+class CensusDetailSitemap(Sitemap):
+    """Individual census record detail pages (approved only)."""
+
+    changefreq = "monthly"
+    priority = 0.4
+    limit = 1000
+
+    def items(self):
+        return CensusSchedule.objects.filter(
+            transcription_status="approved"
+        ).order_by("-updated_at")
+
+    def location(self, obj):
+        return reverse("census_detail", kwargs={"resource_id": obj.resource_id})
+
+    def lastmod(self, obj):
+        return obj.updated_at

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,9 +1,28 @@
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.contrib.sitemaps.views import sitemap
 from django.urls import include, path
 
 from religious_ecologies.views import index
+
+from .sitemaps import (
+    BlogPostSitemap,
+    CensusBrowserStateSitemap,
+    CensusDetailSitemap,
+    PageSitemap,
+    StaticViewSitemap,
+    VisualizationSitemap,
+)
+
+sitemaps = {
+    "static": StaticViewSitemap,
+    "pages": PageSitemap,
+    "blog": BlogPostSitemap,
+    "visualizations": VisualizationSitemap,
+    "census-states": CensusBrowserStateSitemap,
+    "census-records": CensusDetailSitemap,
+}
 
 admin.site.site_header = "Religious Ecologies"
 admin.site.site_title = "Religious Ecologies Data Admin"
@@ -12,6 +31,12 @@ admin.site.index_title = "Religious Ecologies Data Admin"
 urlpatterns = [
     path("", index, name="index"),
     path("admin/", admin.site.urls),
+    path(
+        "sitemap.xml",
+        sitemap,
+        {"sitemaps": sitemaps},
+        name="django.contrib.sitemaps.views.sitemap",
+    ),
     path("census/", include("census.urls")),
     path("analytics/", include("analytics.urls")),
     path("", include("pages.urls")),

--- a/templates/base.html
+++ b/templates/base.html
@@ -61,7 +61,7 @@
                     </div>
                     <!-- Mobile menu button -->
                     <div class="md:hidden">
-                        <button id="mobile-menu-button" class="text-white">
+                        <button id="mobile-menu-button" class="text-white" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="mobile-menu">
                             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
                             </svg>
@@ -110,49 +110,63 @@
 
         <!-- Footer -->
         <footer class="bg-surface-tertiary border-t border-gray-200">
-            <div class="container mx-auto px-4 py-8">
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-                    <div>
-                        <h3 class="text-lg font-semibold mb-2 text-content-primary font-heading">American Religious Ecologies</h3>
-                        <p class="text-content-secondary mb-4">Exploring the religious landscape of America</p>
-                        <p class="text-content-tertiary text-sm">Roy Rosenzweig Center for History and New Media</p>
-                        <p class="text-content-tertiary text-sm">George Mason University</p>
+            <div class="container mx-auto px-4 py-10">
+                <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-8">
+                    <div class="sm:col-span-2 flex flex-col">
+                        <p class="text-sm text-content-tertiary leading-relaxed mb-6">American Religious Ecologies digitizes and publishes the 1926 Federal Census of Religious Bodies to make historical American religious data searchable and accessible. Generously funded in part by the <a href="https://www.neh.gov/" class="text-religious-primary border-b border-religious-primary hover:text-primary-700 transition-colors">National Endowment for the Humanities</a> and developed by the <a href="https://rrchnm.org/" class="text-religious-primary border-b border-religious-primary hover:text-primary-700 transition-colors">Roy Rosenzweig Center for History and New Media</a> at <a href="https://gmu.edu" class="text-religious-primary border-b border-religious-primary hover:text-primary-700 transition-colors">George Mason University</a>. All of the census schedules on this website are in the public domain.</p>
+                        <div class="flex flex-col sm:flex-row items-start sm:items-center gap-4 sm:gap-6 mt-auto">
+                            <a href="https://rrchnm.org/">
+                                <img src="{% static 'images/rrchnm-logo-3.png' %}"
+                                     alt="Roy Rosenzweig Center for History and New Media"
+                                     class="h-10 w-auto opacity-80 hover:opacity-100 transition-opacity">
+                            </a>
+                            <a href="https://gmu.edu">
+                                <img src="{% static 'images/gmu-logo-2.png' %}"
+                                     alt="George Mason University"
+                                     class="h-12 w-auto opacity-80 hover:opacity-100 transition-opacity">
+                            </a>
+                            <a href="https://www.neh.gov/">
+                                <img src="{% static 'images/NEH-Preferred-Seal.png' %}"
+                                     alt="National Endowment for the Humanities"
+                                     class="h-12 w-auto opacity-80 hover:opacity-100 transition-opacity">
+                            </a>
+                        </div>
                     </div>
 
                     <div>
-                        <h4 class="font-semibold mb-3 text-content-primary font-heading">Quick Links</h4>
-                        <div><a href="/census/api/" class="text-religious-primary hover:text-primary-700 transition-colors">API</a></div>
-                        <div><a href="{% url 'locations_browse' %}" class="text-religious-primary hover:text-primary-700 transition-colors">Locations</a></div>
-                        <div><a href="{% url 'denominations_browse' %}" class="text-religious-primary hover:text-primary-700 transition-colors">Denominations</a></div>
-                        <div><a href="{% url 'census_browser' %}" class="text-religious-primary hover:text-primary-700 transition-colors">Records</a></div>
+                        <h4 class="font-semibold mb-3 text-content-primary font-heading">Explore</h4>
+                        <ul class="space-y-2 text-sm">
+                            {% for page in nav_pages %}
+                                <li><a href="{% url 'page_detail' page.slug %}" class="text-content-secondary hover:text-religious-primary transition-colors">{{ page.get_nav_title }}</a></li>
+                            {% endfor %}
+                            <li><a href="{% url 'visualization-list' %}" class="text-content-secondary hover:text-religious-primary transition-colors">Visualizations</a></li>
+                        </ul>
+
+                        <h4 class="font-semibold mb-3 mt-6 text-content-primary font-heading">Resources</h4>
+                        <ul class="space-y-2 text-sm">
+                            <li><a href="{% url 'blog-list' %}" class="text-content-secondary hover:text-religious-primary transition-colors">Blog</a></li>
+                            <li><a href="{% url 'api_documentation' %}" class="text-content-secondary hover:text-religious-primary transition-colors">API Documentation</a></li>
+                        </ul>
                     </div>
 
-                    <div>
-                        {% load socialaccount %}
-                        <h4 class="font-semibold mb-3 text-content-primary font-heading">Account</h4>
-                        {% if user.is_authenticated %}
-                            <div class="text-sm space-y-2">
-                                <p class="text-content-secondary">Welcome, {{ user.username }}!</p>
-                                <div><a href="{% url 'account_logout' %}" class="text-religious-primary hover:text-primary-700 transition-colors">Logout</a></div>
-                            </div>
-                        {% else %}
-                            <div class="space-y-2 text-sm">
-                                <div><a href="{% url 'account_login' %}" class="text-religious-primary hover:text-primary-700 transition-colors">Login</a></div>
-                                <div><a href="{% url 'account_signup' %}" class="text-religious-primary hover:text-primary-700 transition-colors">Sign Up</a></div>
-                                {% comment %}
-                                <div class="pt-2 border-t border-gray-300">
-                                    <div><a href="{% provider_login_url 'github' %}" class="text-content-secondary hover:text-religious-primary transition-colors">Sign in with GitHub</a></div>
-                                    <div><a href="{% provider_login_url 'google' %}" class="text-content-secondary hover:text-religious-primary transition-colors">Sign in with Google</a></div>
-                                </div>
-                                {% endcomment %}
-                            </div>
-                        {% endif %}
-                    </div>
-                </div>
+                    <div class="flex flex-col">
+                        <h4 class="font-semibold mb-3 text-content-primary font-heading">Browse Data</h4>
+                        <ul class="space-y-2 text-sm">
+                            <li><a href="{% url 'census_browser' %}" class="text-content-secondary hover:text-religious-primary transition-colors">Browse Schedules</a></li>
+                            <li><a href="{% url 'locations_browse' %}" class="text-content-secondary hover:text-religious-primary transition-colors">Browse by Counties</a></li>
+                            <li><a href="{% url 'browse_popplaces' %}" class="text-content-secondary hover:text-religious-primary transition-colors">Browse by Populated Places</a></li>
+                            <li><a href="{% url 'denominations_browse' %}" class="text-content-secondary hover:text-religious-primary transition-colors">Browse by Denominations</a></li>
+                        </ul>
 
-                <div class="border-t border-gray-300 pt-6 mt-8">
-                    <div class="flex flex-col md:flex-row justify-between items-center text-sm text-content-tertiary">
-                        <p class="mt-2 md:mt-0"><a href="https://religiousecologies.org/">American Religious Ecologies</a> is generously funded in part by the <a href="https://www.neh.gov/">National Endowment for the Humanities</a> and developed by the <a href="https://rrchnm.org/">Roy Rosenzweig Center for History and New Media</a> at <a href="https://gmu.edu">George Mason University</a>. All of the census schedules on this website are in the public domain.</p>
+                        <div class="mt-auto text-sm">
+                            {% if user.is_authenticated %}
+                                <a href="/admin/" class="text-content-tertiary hover:text-religious-primary transition-colors">Admin</a>
+                                <span class="text-content-tertiary mx-1">&middot;</span>
+                                <a href="{% url 'account_logout' %}" class="text-content-tertiary hover:text-religious-primary transition-colors">Logout</a>
+                            {% else %}
+                                <a href="{% url 'account_login' %}" class="text-content-tertiary hover:text-religious-primary transition-colors">Login</a>
+                            {% endif %}
+                        </div>
                     </div>
                 </div>
             </div>
@@ -161,7 +175,9 @@
         <!-- JavaScript for mobile menu toggle -->
         <script>
             document.getElementById('mobile-menu-button').addEventListener('click', function() {
-                document.getElementById('mobile-menu').classList.toggle('hidden');
+                var menu = document.getElementById('mobile-menu');
+                menu.classList.toggle('hidden');
+                this.setAttribute('aria-expanded', !menu.classList.contains('hidden'));
             });
 
             // Toggle mobile records submenu

--- a/templates/census/browser.html
+++ b/templates/census/browser.html
@@ -138,7 +138,7 @@
             font-weight: 600;
             text-transform: uppercase;
             letter-spacing: 0.06em;
-            color: #9ca3af;
+            color: #6b7280;
             margin-bottom: 0.75rem;
         }
 
@@ -204,8 +204,8 @@
             <form method="get" class="space-y-5" id="filter-form">
                 <!-- Search -->
                 <div>
-                    <label class="block text-sm font-medium text-content-secondary mb-2">Search</label>
-                    <input type="text" name="search" value="{{ search }}"
+                    <label for="search-input" class="block text-sm font-medium text-content-secondary mb-2">Search</label>
+                    <input type="text" name="search" id="search-input" value="{{ search }}"
                            placeholder="Search records, churches, denominations..."
                            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-religious-primary focus:border-transparent">
                 </div>
@@ -215,7 +215,7 @@
                     <div class="filter-group-label">Denomination</div>
                     <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
                         <div>
-                            <label class="block text-sm font-medium text-content-secondary mb-2">Denomination Family</label>
+                            <label for="family-select" class="block text-sm font-medium text-content-secondary mb-2">Denomination Family</label>
                             <select name="family" id="family-select" class="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-religious-primary focus:border-transparent">
                                 <option value="">All Families</option>
                                 {% for family in census_families %}
@@ -226,7 +226,7 @@
                             </select>
                         </div>
                         <div>
-                            <label class="block text-sm font-medium text-content-secondary mb-2">Denomination</label>
+                            <label for="denomination-select" class="block text-sm font-medium text-content-secondary mb-2">Denomination</label>
                             <select name="denomination" id="denomination-select"
                                     {% if not family_filter %}disabled{% endif %}
                                     class="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-religious-primary focus:border-transparent disabled:bg-gray-100 disabled:text-gray-400 disabled:cursor-not-allowed">
@@ -248,7 +248,7 @@
                     <div class="filter-group-label">Location</div>
                     <div class="grid grid-cols-1 lg:grid-cols-4 gap-4">
                         <div>
-                            <label class="block text-sm font-medium text-content-secondary mb-2">State</label>
+                            <label for="state-select" class="block text-sm font-medium text-content-secondary mb-2">State</label>
                             <select id="state-select" class="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-religious-primary focus:border-transparent">
                                 <option value="">All States</option>
                                 {% for state in states %}
@@ -259,7 +259,7 @@
                             </select>
                         </div>
                         <div>
-                            <label class="block text-sm font-medium text-content-secondary mb-2">County</label>
+                            <label for="county-select" class="block text-sm font-medium text-content-secondary mb-2">County</label>
                             <select id="county-select"
                                     {% if not location_filter %}disabled{% endif %}
                                     class="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-religious-primary focus:border-transparent disabled:bg-gray-100 disabled:text-gray-400 disabled:cursor-not-allowed">
@@ -267,7 +267,7 @@
                             </select>
                         </div>
                         <div>
-                            <label class="block text-sm font-medium text-content-secondary mb-2">Populated Place</label>
+                            <label for="place-select" class="block text-sm font-medium text-content-secondary mb-2">Populated Place</label>
                             <select id="place-select"
                                     {% if not county_filter %}disabled{% endif %}
                                     class="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-religious-primary focus:border-transparent disabled:bg-gray-100 disabled:text-gray-400 disabled:cursor-not-allowed">
@@ -275,8 +275,8 @@
                             </select>
                         </div>
                         <div>
-                            <label class="block text-sm font-medium text-content-secondary mb-2">Urban or Rural</label>
-                            <select name="urban_rural"
+                            <label for="urban-rural-select" class="block text-sm font-medium text-content-secondary mb-2">Urban or Rural</label>
+                            <select name="urban_rural" id="urban-rural-select"
                                     class="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-religious-primary focus:border-transparent">
                                 <option value="">Any</option>
                                 <option value="urban" {% if urban_rural == "urban" %}selected{% endif %}>Urban</option>
@@ -496,7 +496,7 @@
                                     {% if record.original_image %}
                                         <div class="aspect-[4/3] rounded-lg overflow-hidden">
                                             <img src="{% thumbnail record.original_image 'medium' %}"
-                                                 alt="Census Schedule {{ record.resource_id }}"
+                                                 alt="Archival image of census schedule {{ record.resource_id }}. See the transcription for the contents of this document."
                                                  class="w-full h-full object-cover">
                                         </div>
                                     {% else %}

--- a/templates/census/demographics_map.html
+++ b/templates/census/demographics_map.html
@@ -208,7 +208,7 @@
                                 <span class="text-sm font-medium text-gray-700">Clustering</span>
                             </div>
                             <div class="flex items-center">
-                                <label class="text-sm font-medium text-gray-700 mr-2">Size by:</label>
+                                <label for="markerSizeBy" class="text-sm font-medium text-gray-700 mr-2">Size by:</label>
                                 <select id="markerSizeBy" class="text-sm border border-gray-300 rounded px-2 py-1">
                                     <option value="fixed">Fixed</option>
                                     <option value="members">Total Members</option>
@@ -224,12 +224,13 @@
                         <h3 class="font-medium text-gray-700 mb-2">Demographics</h3>
                         <div class="space-y-2">
                             <div>
-                                <label class="text-sm text-gray-600">Members:</label>
+                                <label for="minMembers" class="text-sm text-gray-600">Members:</label>
                                 <div class="flex gap-1">
-                                    <input type="number" id="minMembers" placeholder="Min" class="filter-input text-sm">
-                                    <input type="number" id="maxMembers" placeholder="Max" class="filter-input text-sm">
+                                    <input type="number" id="minMembers" placeholder="Min" aria-label="Minimum members" class="filter-input text-sm">
+                                    <input type="number" id="maxMembers" placeholder="Max" aria-label="Maximum members" class="filter-input text-sm">
                                 </div>
                             </div>
+                            <label for="genderFilter" class="sr-only">Gender filter</label>
                             <select id="genderFilter" class="filter-input text-sm">
                                 <option value="">All Genders</option>
                                 <option value="male_majority">Male Majority (>60%)</option>
@@ -243,6 +244,7 @@
                     <div>
                         <h3 class="font-medium text-gray-700 mb-2">Age & Education</h3>
                         <div class="space-y-2">
+                            <label for="ageFilter" class="sr-only">Age filter</label>
                             <select id="ageFilter" class="filter-input text-sm">
                                 <option value="">All Ages</option>
                                 <option value="youth_heavy">Youth Heavy (>30% under 13)</option>
@@ -279,7 +281,7 @@
                     </div>
                 </div>
 
-                <div id="mapStatus" class="text-sm text-gray-500 mt-2"></div>
+                <div id="mapStatus" class="text-sm text-gray-600 mt-2"></div>
             </div>
         </div>
 
@@ -294,7 +296,7 @@
                         <button id="clearFamilyFilter" class="text-sm text-religious-primary hover:text-primary-800">Clear</button>
                     </div>
                     <div id="familyList" class="max-h-64 overflow-y-auto">
-                        <div class="text-gray-500 text-sm text-center py-4">Loading...</div>
+                        <div class="text-gray-600 text-sm text-center py-4">Loading...</div>
                     </div>
                 </div>
 
@@ -304,9 +306,10 @@
                         <h2 class="text-lg font-semibold">Denominations</h2>
                         <button id="clearDenominationFilter" class="text-sm text-religious-primary hover:text-primary-800">Clear</button>
                     </div>
+                    <label for="denominationSearch" class="sr-only">Search denominations</label>
                     <input type="text" id="denominationSearch" placeholder="Search denominations..." class="filter-input mb-2">
                     <div id="denominationList" class="max-h-64 overflow-y-auto">
-                        <div class="text-gray-500 text-sm text-center py-4">Select a family first</div>
+                        <div class="text-gray-600 text-sm text-center py-4">Select a family first</div>
                     </div>
                 </div>
             </div>
@@ -526,7 +529,7 @@
                 const statsContainer = document.getElementById('demographicStats');
 
                 if (allMarkers.length === 0) {
-                    statsContainer.innerHTML = '<div class="text-gray-500 text-sm">No data to display</div>';
+                    statsContainer.innerHTML = '<div class="text-gray-600 text-sm">No data to display</div>';
                     return;
                 }
 
@@ -889,7 +892,7 @@
           // Function to load families data (returns Promise for chaining)
             function loadFamilies() {
                 const familyList = document.getElementById('familyList');
-                familyList.innerHTML = '<div class="text-gray-500 text-sm text-center py-4">Loading...</div>';
+                familyList.innerHTML = '<div class="text-gray-600 text-sm text-center py-4">Loading...</div>';
 
                 return fetch('/census/api/denominations/families/')
                     .then(response => {
@@ -909,7 +912,7 @@
                                 familyHTML += `
                                     <div class="family-card" data-family="${family.name}">
                                         <div class="font-medium">${family.name}</div>
-                                        <div class="text-sm text-gray-500">
+                                        <div class="text-sm text-gray-600">
                                             ${family.count} denomination${family.count !== 1 ? 's' : ''}
                                         </div>
                                     </div>
@@ -940,7 +943,7 @@
                           // Auto-select the default family after cards are rendered
                             selectFamily(DEFAULT_FAMILY);
                         } else {
-                            familyList.innerHTML = '<div class="text-gray-500 text-sm text-center py-4">No families found</div>';
+                            familyList.innerHTML = '<div class="text-gray-600 text-sm text-center py-4">No families found</div>';
                         }
                     })
                     .catch(error => {
@@ -952,7 +955,7 @@
             // Function to load denominations for a specific family (same as original)
             function loadDenominations(familyName) {
                 const denominationList = document.getElementById('denominationList');
-                denominationList.innerHTML = '<div class="text-gray-500 text-sm text-center py-4">Loading...</div>';
+                denominationList.innerHTML = '<div class="text-gray-600 text-sm text-center py-4">Loading...</div>';
 
               fetch(`/census/api/denominations/by_family/?family_relec=${encodeURIComponent(familyName)}`)
                     .then(response => {
@@ -1001,7 +1004,7 @@
                                 });
                             });
                         } else {
-                            denominationList.innerHTML = '<div class="text-gray-500 text-sm text-center py-4">No denominations found</div>';
+                            denominationList.innerHTML = '<div class="text-gray-600 text-sm text-center py-4">No denominations found</div>';
                         }
                     })
                     .catch(error => {

--- a/templates/census/detail.html
+++ b/templates/census/detail.html
@@ -233,7 +233,7 @@
                     <div class="image-viewer">
                         {% if census_record.original_image %}
                             <img src="{% thumbnail census_record.original_image 'large' %}"
-                                 alt="Census Schedule {{ census_record.resource_id }}"
+                                 alt="Archival image of census schedule {{ census_record.resource_id }}. See the transcription below for the contents of this document."
                                  class="w-full h-auto">
                             <div class="p-4 bg-gray-50 text-sm text-content-tertiary">
                                 <a href="{{ census_record.original_image.url }}"

--- a/templates/census/map.html
+++ b/templates/census/map.html
@@ -140,7 +140,7 @@
 
                         <div id="familyList" class="max-h-56 overflow-y-auto mb-3">
                         <!-- Family items will be populated here via JS -->
-                            <div class="text-gray-500 text-sm text-center py-4">Loading...</div>
+                            <div class="text-gray-600 text-sm text-center py-4">Loading...</div>
                         </div>
                     </div>
 
@@ -151,12 +151,13 @@
                             <button id="clearDenominationFilter" class="text-sm text-indigo-600 hover:text-indigo-800">Clear</button>
                         </div>
 
+                        <label for="denominationSearch" class="sr-only">Search denominations</label>
                         <input type="text" id="denominationSearch" placeholder="Search denominations..."
                                class="w-full border border-gray-300 rounded p-2 mb-2">
 
                         <div id="denominationList" class="max-h-64 overflow-y-auto">
                         <!-- Denomination items will be populated here via JS -->
-                            <div class="text-gray-500 text-sm text-center py-4">Select a family first</div>
+                            <div class="text-gray-600 text-sm text-center py-4">Select a family first</div>
                         </div>
                     </div>
                 </div>
@@ -187,7 +188,7 @@
                         </label>
                         <span class="text-sm font-medium text-gray-700">Clustering</span>
                     </div>
-                    <div id="mapStatus" class="text-sm text-gray-500"></div>
+                    <div id="mapStatus" class="text-sm text-gray-600"></div>
                 </div>
 
             <!-- The map container -->
@@ -518,7 +519,7 @@
     // Function to load families data
             function loadFamilies() {
                 const familyList = document.getElementById('familyList');
-                familyList.innerHTML = '<div class="text-gray-500 text-sm text-center py-4">Loading...</div>';
+                familyList.innerHTML = '<div class="text-gray-600 text-sm text-center py-4">Loading...</div>';
 
                 fetch('/census/api/denominations/families/')
                     .then(response => {
@@ -541,7 +542,7 @@
                                 familyHTML += `
                             <div class="family-card" data-family="${family.name}">
                                 <div class="font-medium">${family.name}</div>
-                                <div class="text-sm text-gray-500">
+                                <div class="text-sm text-gray-600">
                                     ${family.count} denomination${family.count !== 1 ? 's' : ''}
                                 </div>
                             </div>
@@ -583,7 +584,7 @@
                                 }
                             }
                         } else {
-                            familyList.innerHTML = '<div class="text-gray-500 text-sm text-center py-4">No families found</div>';
+                            familyList.innerHTML = '<div class="text-gray-600 text-sm text-center py-4">No families found</div>';
                         }
                     })
                     .catch(error => {
@@ -595,7 +596,7 @@
     // Function to load denominations for a specific family
             function loadDenominations(familyName) {
                 const denominationList = document.getElementById('denominationList');
-                denominationList.innerHTML = '<div class="text-gray-500 text-sm text-center py-4">Loading...</div>';
+                denominationList.innerHTML = '<div class="text-gray-600 text-sm text-center py-4">Loading...</div>';
 
               fetch(`/census/api/denominations/by_family/?family_relec=${encodeURIComponent(familyName)}`)
                     .then(response => {
@@ -646,7 +647,7 @@
                                 });
                             });
                         } else {
-                            denominationList.innerHTML = '<div class="text-gray-500 text-sm text-center py-4">No denominations found</div>';
+                            denominationList.innerHTML = '<div class="text-gray-600 text-sm text-center py-4">No denominations found</div>';
                         }
                     })
                     .catch(error => {
@@ -682,7 +683,7 @@
                 });
 
         // Clear denomination selection and list
-                document.getElementById('denominationList').innerHTML = '<div class="text-gray-500 text-sm text-center py-4">Select a family first</div>';
+                document.getElementById('denominationList').innerHTML = '<div class="text-gray-600 text-sm text-center py-4">Select a family first</div>';
 
         // Clear filters on map
                 currentFamily = null;

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static %}
+{% load static humanize %}
 
 {% block title %}Religious Ecologies - Mapping American Religious History{% endblock %}
 
@@ -30,7 +30,7 @@
         .cta-button {
             display: inline-flex;
             align-items: center;
-            padding: 0.75rem 2rem;
+            padding: 0.75rem 1.25rem;
             background-color: #0060b1;
             color: white;
             border-radius: 8px;
@@ -88,28 +88,6 @@
             font-weight: 500;
             text-transform: uppercase;
             letter-spacing: 0.05em;
-        }
-
-        .partner-logos {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-            gap: 2rem;
-            align-items: center;
-            margin-top: 3rem;
-        }
-
-        .partner-logo {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            padding: 1rem;
-            background: white;
-            border-radius: 8px;
-            border: 1px solid #e5e7eb;
-            min-height: 80px;
-            color: #9ca3af;
-            font-size: 0.875rem;
-            text-align: center;
         }
 
         .newsletter-signup {
@@ -244,15 +222,15 @@
                 </h2>
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-4xl mx-auto">
                     <div class="stat-card">
-                        <span class="stat-number">{{ total_schedules|floatformat:0 }}</span>
+                        <span class="stat-number">{{ total_schedules|intcomma }}</span>
                         <div class="stat-label">Schedules Digitized</div>
                     </div>
                     <div class="stat-card">
-                        <span class="stat-number">{{ total_denominations }}</span>
+                        <span class="stat-number">{{ total_denominations|intcomma }}</span>
                         <div class="stat-label">Denominations</div>
                     </div>
                     <div class="stat-card">
-                        <span class="stat-number">{{ total_counties|floatformat:0 }}</span>
+                        <span class="stat-number">{{ total_counties|intcomma }}</span>
                         <div class="stat-label">Counties</div>
                     </div>
                 </div>
@@ -282,7 +260,7 @@
                                                 {{ denomination.name }}
                                             </a>
                                         </td>
-                                        <td class="px-4 py-3 text-right font-medium">{{ denomination.schedule_count }}</td>
+                                        <td class="px-4 py-3 text-right font-medium">{{ denomination.schedule_count|intcomma }}</td>
                                     </tr>
                                 {% endfor %}
                             </tbody>
@@ -312,7 +290,7 @@
                                                 {{ county.county__name }}, {{ county.county__state__code }}
                                             </a>
                                         </td>
-                                        <td class="px-4 py-3 text-right font-medium">{{ county.schedule_count }}</td>
+                                        <td class="px-4 py-3 text-right font-medium">{{ county.schedule_count|intcomma }}</td>
                                     </tr>
                                 {% endfor %}
                             </tbody>
@@ -360,6 +338,30 @@
         </div>
     </section>
 
+    <!-- Video + About -->
+    <section class="content-section bg-white">
+        <div class="section-container">
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-12 items-start">
+                <div>
+                    <h2 class="text-3xl font-bold text-content-primary mb-6 font-heading">
+                        Learn about the U.S. Census of Religious Bodies
+                    </h2>
+                    <div class="video-container">
+                        <iframe src="https://www.youtube.com/embed/HNgJFwtanyo?si=alL2HbITlIF7HZU7" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                    </div>
+                </div>
+                <div>
+                    <p class="text-content-secondary leading-relaxed mb-6">
+                        While some Americans have lived in rich religious ecologies, surrounded by a plethora of denominational choices, others have lived in places with only one or a few religious options. Using new and existing datasets, American Religious Ecologies documents and maps these environments. How did certain groups come to thrive in particular places, and how were they divided by race and social class? Did cities, towns, and rural areas feature meaningful religious pluralism and diversity, or were they dominated by some particular religious group? How did the balance of diversity and dominance vary across space and time?
+                    </p>
+                    <p class="text-content-secondary leading-relaxed">
+                        While scholars have often studied the religious ecology of a particular city or place, studying how those ecologies varied across the nation has been difficult because of the lack of data that is available. The American Religious Ecologies project is creating new datasets from historical sources and new ways of visualizing them so that we can better understand the history of American religion.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </section>
+
     <!-- Newsletter Signup -->
     <section class="newsletter-signup">
         <div class="section-container text-center">
@@ -368,7 +370,8 @@
                 Get the latest updates on new datasets, features, and research findings.
             </p>
             <form action="https://rrchnm.us14.list-manage.com/subscribe/post?u=61d42b8d0bd0af50c96813715&amp;id=6d054e762f&amp;f_id=00efe1e6f0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="newsletter-form" target="_blank">
-                <input type="email" name="EMAIL" placeholder="Enter your email address" class="newsletter-input" required>
+                <label for="mce-EMAIL" class="sr-only">Email address</label>
+                <input type="email" name="EMAIL" id="mce-EMAIL" placeholder="Enter your email address" class="newsletter-input" aria-label="Email address" required>
                 <div style="position: absolute; left: -5000px;" aria-hidden="true">
                     <input type="text" name="b_61d42b8d0bd0af50c96813715_6d054e762f" tabindex="-1" value="">
                 </div>
@@ -377,37 +380,4 @@
         </div>
     </section>
 
-    <section class="content-section bg-white">
-        <div class="section-container">
-            <h2 class="text-3xl font-bold text-content-primary mb-6 font-heading">
-                Learn about the U.S. Census of Religious Bodies
-            </h2>
-            <div class="video-container">
-                <iframe src="https://www.youtube.com/embed/HNgJFwtanyo?si=alL2HbITlIF7HZU7" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-            </div>
-        </div>
-    </section>
-
-    <!-- Partners -->
-    <section class="content-section bg-surface-secondary">
-        <div class="section-container text-center">
-            <div class="partner-logos">
-                <div class="partner-logo">
-                    <img src="{% static 'images/rrchnm-logo-3.png' %}"
-                         alt="Roy Rosenzweig Center for History and New Media"
-                         class="max-h-16 w-auto">
-                </div>
-                <div class="partner-logo">
-                    <img src="{% static 'images/gmu-logo-2.png' %}"
-                         alt="George Mason University"
-                         class="max-h-16 w-auto">
-                </div>
-                <div class="partner-logo">
-                    <img src="{% static 'images/NEH-Preferred-Seal.png' %}"
-                         alt="National Endowment for the Humanities"
-                         class="max-h-16 w-auto">
-                </div>
-            </div>
-        </div>
-    </section>
 {% endblock %}

--- a/theme/static_src/tailwind.config.js
+++ b/theme/static_src/tailwind.config.js
@@ -71,7 +71,7 @@ module.exports = {
         'content': {
           'primary': '#111827',    // Very dark gray for main text
           'secondary': '#374151',  // Medium gray for secondary text
-          'tertiary': '#6b7280',   // Light gray for labels
+          'tertiary': '#626971',   // Light gray for labels (4.5:1 on gray-100)
           'quaternary': '#9ca3af', // Very light gray for placeholders
         },
 


### PR DESCRIPTION
## Summary

- **WCAG 2.0 AA compliance**: Resolved all 103 pa11y errors across 10 representative pages — form labels, color contrast, ARIA attributes, and archival image alt text
- **Django sitemap**: Added `django.contrib.sitemaps` serving at `/sitemap.xml` covering all public page types
- **Footer redesign**: Three-column layout with project description + partner logos, Explore/Resources links, and Browse Data links mirroring the nav bar
- **Home page updates**: Repositioned YouTube video into two-column layout with project description, removed duplicate partner logos section, added thousands separators to stats and top 25 tables, fixed CTA button wrapping at tablet breakpoints

## Accessibility fixes detail

| Issue | Count | Fix |
|-------|-------|-----|
| Mobile menu button missing accessible name | 10 | Added `aria-label`, `aria-expanded`, `aria-controls` |
| Footer text contrast (4.39:1 < 4.5:1) | 70 | Darkened `text-content-tertiary` to `#626971` |
| Form fields without labels | 16 | Linked labels via `for`/`id`, added `sr-only` labels |
| Filter group label contrast (2.54:1) | 2 | Darkened from `#9ca3af` to `#6b7280` |
| Map text contrast (4.32:1, 4.499:1) | 2 | Changed `text-gray-500` to `text-gray-600` |
| Newsletter input missing label | 1 | Added `label` + `aria-label` |
| Generic image alt text | 2 | Updated to describe archival document and direct to transcription |

## Test plan

- [x] Run `npx pa11y http://localhost:8000/ --standard WCAG2AA` on representative pages — should return 0 errors
- [x] Verify footer layout on mobile, tablet, and desktop
- [x] Verify home page video + text two-column layout
- [x] Verify sitemap at `/sitemap.xml` returns valid XML
- [x] Rebuild Tailwind CSS after deploy: `just build-css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)