### PR TITLE
fix: Add pymemcache resilience options for ASGI concurrency

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -490,6 +490,13 @@ if MEMCACHED_URL:
             "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
             "LOCATION": MEMCACHED_URL,
             "TIMEOUT": 900,  # Default 15-minute cache timeout
+            "OPTIONS": {
+                "no_delay": True,
+                "ignore_exc": True,  # Return cache miss on errors, don't crash
+                "connect_timeout": 3,
+                "timeout": 3,
+                "use_pooling": True,
+            },
         }
     }
 else:


### PR DESCRIPTION
## Summary
- Add `ignore_exc=True` so cache errors return a miss instead of an ISE
- Add `use_pooling=True` for proper connection handling under concurrent ASGI threads
- Add `connect_timeout` and `timeout` (3s) to prevent hung connections from blocking requests
- Add `no_delay=True` for reduced latency

Fixes the `AttributeError: 'NoneType' object has no attribute 'recv'` and `OSError: Bad file descriptor` errors seen in production when crawlers hit many detail pages simultaneously.