### PR TITLE
Fix N+1 queries, consolidate viz URLs, and improve browser filters

### DIFF
--- a/census/api_views.py
+++ b/census/api_views.py
@@ -30,65 +30,38 @@ class DenominationViewSet(viewsets.ReadOnlyModelViewSet):
     @action(detail=False, methods=["get"])
     def families(self, request):
         """Return unique denomination families for filtering - only those with location data"""
-        # Get families that have at least one ReligiousBody with location data
-        # Filter through census_record -> populated_place for the new location hierarchy
-        census_families = (
-            Denomination.objects.filter(
-                religiousbody__census_record__populated_place__isnull=False,
-            )
-            .values_list("family_census", flat=True)
-            .distinct()
+        location_filter = {
+            "religiousbody__census_record__populated_place__isnull": False,
+        }
+
+        # Single query per family type using aggregation instead of N+1 loop
+        census_family_data = (
+            Denomination.objects.filter(**location_filter)
+            .exclude(family_census__isnull=True)
+            .exclude(family_census="")
+            .values("family_census")
+            .annotate(count=Count("id", distinct=True))
             .order_by("family_census")
         )
 
-        relec_families = (
-            Denomination.objects.filter(
-                religiousbody__census_record__populated_place__isnull=False,
-            )
-            .values_list("family_relec", flat=True)
-            .distinct()
+        relec_family_data = (
+            Denomination.objects.filter(**location_filter)
+            .exclude(family_relec__isnull=True)
+            .exclude(family_relec="")
+            .values("family_relec")
+            .annotate(count=Count("id", distinct=True))
             .order_by("family_relec")
         )
-
-        # Count denominations in each census family that have location data
-        census_family_counts = {}
-        for family in census_families:
-            if family:  # Skip empty family names
-                count = (
-                    Denomination.objects.filter(
-                        family_census=family,
-                        religiousbody__census_record__populated_place__isnull=False,
-                    )
-                    .distinct()
-                    .count()
-                )
-                census_family_counts[family] = count
-
-        # Count denominations in each RelEc family that have location data
-        relec_family_counts = {}
-        for family in relec_families:
-            if family:  # Skip empty family names
-                count = (
-                    Denomination.objects.filter(
-                        family_relec=family,
-                        religiousbody__census_record__populated_place__isnull=False,
-                    )
-                    .distinct()
-                    .count()
-                )
-                relec_family_counts[family] = count
 
         return Response(
             {
                 "census_families": [
-                    {"name": family, "count": census_family_counts.get(family, 0)}
-                    for family in census_families
-                    if family
+                    {"name": f["family_census"], "count": f["count"]}
+                    for f in census_family_data
                 ],
                 "relec_families": [
-                    {"name": family, "count": relec_family_counts.get(family, 0)}
-                    for family in relec_families
-                    if family
+                    {"name": f["family_relec"], "count": f["count"]}
+                    for f in relec_family_data
                 ],
             }
         )
@@ -198,89 +171,65 @@ class ReligiousBodyViewSet(viewsets.ReadOnlyModelViewSet):
         List unique denomination families with counts.
 
         Returns both census families and RelEc families, with counts of denominations
-        and congregations in each family.
+        and congregations in each family. Uses aggregation to avoid N+1 queries.
         """
-        try:
-            # Get all unique census families with counts
-            census_families_data = []
+        from django.db.models import Q
 
-            census_families = (
-                Denomination.objects.filter(family_census__isnull=False)
-                .values("family_census")
-                .annotate(
-                    denomination_count=Count("id", distinct=True),
-                    total_congregation_count=Count("religiousbody", distinct=True),
-                )
-                .order_by("family_census")
+        # Census families — single query with all counts
+        census_families_data = (
+            Denomination.objects.filter(family_census__isnull=False)
+            .exclude(family_census="")
+            .values("family_census")
+            .annotate(
+                denomination_count=Count("id", distinct=True),
+                total_congregation_count=Count("religiousbody", distinct=True),
+                congregation_count_with_location=Count(
+                    "religiousbody",
+                    distinct=True,
+                    filter=Q(religiousbody__census_record__populated_place__isnull=False),
+                ),
             )
+            .order_by("family_census")
+        )
 
-            for family in census_families:
-                if family["family_census"]:
-                    family_name = family["family_census"]
-                    congregation_count_with_location = (
-                        Denomination.objects.filter(
-                            family_census=family_name,
-                            religiousbody__census_record__populated_place__isnull=False,
-                        )
-                        .values("religiousbody")
-                        .distinct()
-                        .count()
-                    )
-                    census_families_data.append(
-                        {
-                            "name": family_name,
-                            "denominations": family["denomination_count"],
-                            "congregations": congregation_count_with_location,
-                            "total_congregations": family["total_congregation_count"],
-                            "has_location_data": congregation_count_with_location > 0,
-                        }
-                    )
-
-            # Get all unique RelEc families with counts
-            relec_families_data = []
-
-            relec_families = (
-                Denomination.objects.filter(family_relec__isnull=False)
-                .values("family_relec")
-                .annotate(
-                    denomination_count=Count("id", distinct=True),
-                    total_congregation_count=Count("religiousbody", distinct=True),
-                )
-                .order_by("family_relec")
+        # RelEc families — single query with all counts
+        relec_families_data = (
+            Denomination.objects.filter(family_relec__isnull=False)
+            .exclude(family_relec="")
+            .values("family_relec")
+            .annotate(
+                denomination_count=Count("id", distinct=True),
+                total_congregation_count=Count("religiousbody", distinct=True),
+                congregation_count_with_location=Count(
+                    "religiousbody",
+                    distinct=True,
+                    filter=Q(religiousbody__census_record__populated_place__isnull=False),
+                ),
             )
+            .order_by("family_relec")
+        )
 
-            for family in relec_families:
-                if family["family_relec"]:
-                    family_name = family["family_relec"]
-                    congregation_count_with_location = (
-                        Denomination.objects.filter(
-                            family_relec=family_name,
-                            religiousbody__census_record__populated_place__isnull=False,
-                        )
-                        .values("religiousbody")
-                        .distinct()
-                        .count()
-                    )
-                    relec_families_data.append(
-                        {
-                            "name": family_name,
-                            "denominations": family["denomination_count"],
-                            "congregations": congregation_count_with_location,
-                            "total_congregations": family["total_congregation_count"],
-                            "has_location_data": congregation_count_with_location > 0,
-                        }
-                    )
-
-            return Response(
-                {
-                    "census_families": census_families_data,
-                    "relec_families": relec_families_data,
-                }
-            )
-
-        except Exception as e:
-            import traceback
-
-            return Response(
-                {"error": str(e), "traceback": traceback.format_exc()}, status=500
-            )
+        return Response(
+            {
+                "census_families": [
+                    {
+                        "name": f["family_census"],
+                        "denominations": f["denomination_count"],
+                        "congregations": f["congregation_count_with_location"],
+                        "total_congregations": f["total_congregation_count"],
+                        "has_location_data": f["congregation_count_with_location"] > 0,
+                    }
+                    for f in census_families_data
+                ],
+                "relec_families": [
+                    {
+                        "name": f["family_relec"],
+                        "denominations": f["denomination_count"],
+                        "congregations": f["congregation_count_with_location"],
+                        "total_congregations": f["total_congregation_count"],
+                        "has_location_data": f["congregation_count_with_location"] > 0,
+                    }
+                    for f in relec_families_data
+                ],
+            }
+        )

--- a/census/urls.py
+++ b/census/urls.py
@@ -16,25 +16,6 @@ urlpatterns = [
     path("api/", api_root, name="census-api-root"),
     # API endpoints
     path("api/", include(router.urls)),
-    # Visualization views
-    path(
-        "viz/urban-congregations/",
-        views.urban_congregations_map_view,
-        name="urban_congregations_map",
-    ),
-    path(
-        "viz/urban-congregations-simple/",
-        views.urban_congregations_simple_view,
-        name="urban_congregations_simple",
-    ),
-    # Map views
-    path("map/", views.map_view, name="denomination_map"),
-    path("demographics-map/", views.demographics_map_view, name="demographics_map"),
-    path(
-        "viz/populated-places/",
-        views.denomination_geojson_map_view,
-        name="denomination_geojson_map",
-    ),
     # Census browser views
     path("browser/", views.census_browser_view, name="census_browser"),
     path(

--- a/census/views.py
+++ b/census/views.py
@@ -86,6 +86,7 @@ def _get_census_browser_filter_data():
     return data
 
 
+@cache_page(60 * 15)  # 15 minutes
 def map_view(request):
     """Render the map view with denomination filters"""
     # Get all denominations for the filter dropdown
@@ -112,6 +113,7 @@ def map_view(request):
     return render(request, "census/map.html", context)
 
 
+@cache_page(60 * 15)  # 15 minutes
 def demographics_map_view(request):
     """Render the demographics map view with demographic filters"""
     # Get all denominations for the filter dropdown
@@ -486,6 +488,7 @@ def urban_congregations_simple_view(request):
     return render(request, "census/visualizations/urban_congregations_simple.html")
 
 
+@cache_page(60 * 15)  # 15 minutes
 def api_documentation_view(request):
     """
     API Documentation page for the Religious Ecologies Census Data API.

--- a/pages/urls.py
+++ b/pages/urls.py
@@ -1,5 +1,7 @@
 from django.urls import path
 
+from census import views as census_views
+
 from . import views
 
 urlpatterns = [
@@ -12,6 +14,33 @@ urlpatterns = [
         views.VisualizationListView.as_view(),
         name="visualization-list",
     ),
+    # Custom visualization views (rendered by census app views)
+    path(
+        "visualizations/denomination-map/",
+        census_views.map_view,
+        name="denomination_map",
+    ),
+    path(
+        "visualizations/demographics-map/",
+        census_views.demographics_map_view,
+        name="demographics_map",
+    ),
+    path(
+        "visualizations/populated-places-map/",
+        census_views.denomination_geojson_map_view,
+        name="denomination_geojson_map",
+    ),
+    path(
+        "visualizations/urban-congregations/",
+        census_views.urban_congregations_map_view,
+        name="urban_congregations_map",
+    ),
+    path(
+        "visualizations/urban-congregations-simple/",
+        census_views.urban_congregations_simple_view,
+        name="urban_congregations_simple",
+    ),
+    # Generic visualization detail (for model-backed visualizations)
     path(
         "visualizations/<slug:slug>/",
         views.VisualizationDetailView.as_view(),

--- a/pages/views.py
+++ b/pages/views.py
@@ -4,6 +4,8 @@ import markdown
 from django.conf import settings
 from django.http import Http404
 from django.shortcuts import get_object_or_404, render
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 from django.views.generic import DetailView, ListView
 
 from .models import BlogPost, Page, Visualization
@@ -57,6 +59,7 @@ def nav_pages_context(request):
 
 
 # Blog Posts
+@method_decorator(cache_page(60 * 15), name="dispatch")  # 15 minutes
 class BlogListView(ListView):
     model = BlogPost
     template_name = "pages/blog_list.html"
@@ -67,6 +70,7 @@ class BlogListView(ListView):
         return BlogPost.objects.filter(is_draft=False).order_by("-published_date")
 
 
+@method_decorator(cache_page(60 * 15), name="dispatch")  # 15 minutes
 class BlogDetailView(DetailView):
     model = BlogPost
     template_name = "pages/blog_detail.html"
@@ -91,6 +95,7 @@ class BlogDetailView(DetailView):
 
 
 # Visualizations
+@method_decorator(cache_page(60 * 15), name="dispatch")  # 15 minutes
 class VisualizationListView(ListView):
     model = Visualization
     template_name = "pages/visualization_list.html"
@@ -101,6 +106,7 @@ class VisualizationListView(ListView):
         return Visualization.objects.all().order_by("-published_date")
 
 
+@method_decorator(cache_page(60 * 15), name="dispatch")  # 15 minutes
 class VisualizationDetailView(DetailView):
     model = Visualization
     template_name = "pages/visualization_detail.html"

--- a/templates/census/browser.html
+++ b/templates/census/browser.html
@@ -40,7 +40,7 @@
             display: inline-flex;
             align-items: center;
             padding: 0.25rem 0.75rem;
-            border-radius: 9999px;
+            border-radius: 4px;
             font-size: 0.75rem;
             font-weight: 500;
         }
@@ -228,7 +228,7 @@
                         <div>
                             <label for="denomination-select" class="block text-sm font-medium text-content-secondary mb-2">Denomination</label>
                             <select name="denomination" id="denomination-select"
-                                    {% if not family_filter %}disabled{% endif %}
+                                    {% if not family_filter and not denomination_filter %}disabled{% endif %}
                                     class="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-religious-primary focus:border-transparent disabled:bg-gray-100 disabled:text-gray-400 disabled:cursor-not-allowed">
                                 <option value="">All Denominations</option>
                                 {% for denomination in denominations %}
@@ -445,6 +445,18 @@
 
             // Initialize on page load
             document.addEventListener('DOMContentLoaded', function() {
+                // If a denomination is pre-selected but no family is set,
+                // auto-select the denomination's family so the dropdown reflects the filter
+                if (selectedDenomination && !familySelect.value) {
+                    // Find the denomination's family from the data
+                    for (const [family, denoms] of Object.entries(denominationsByFamily)) {
+                        if (denoms.some(d => String(d.id) === selectedDenomination)) {
+                            familySelect.value = family;
+                            break;
+                        }
+                    }
+                }
+
                 updateDenominationOptions();
                 updateCountyOptions();
                 updatePlaceOptions();
@@ -475,9 +487,55 @@
                         {% endif %}
                     </span>
                 </div>
-                <div class="flex gap-2">
-                    {% if search or denomination_filter or family_filter or location_filter or urban_rural or place_filter %}
-                        <span class="badge badge-amber">Filtered</span>
+                <div class="flex flex-wrap gap-2">
+                    {% if search %}
+                        <span class="badge badge-amber inline-flex items-center gap-1">
+                            Search: "{{ search }}"
+                            <a href="{% url 'census_browser' %}?{% if family_filter %}family={{ family_filter|urlencode }}&{% endif %}{% if denomination_filter %}denomination={{ denomination_filter }}&{% endif %}{% if location_filter %}location={{ location_filter }}&{% endif %}{% if county_filter %}county={{ county_filter|urlencode }}&{% endif %}{% if place_filter %}place={{ place_filter|urlencode }}&{% endif %}{% if urban_rural %}urban_rural={{ urban_rural }}&{% endif %}{% if has_membership %}has_membership={{ has_membership }}{% endif %}"
+                               class="ml-1 hover:text-red-700" title="Remove filter">&times;</a>
+                        </span>
+                    {% endif %}
+                    {% if family_filter %}
+                        <span class="badge badge-amber inline-flex items-center gap-1">
+                            Family: {{ family_filter }}
+                            <a href="{% url 'census_browser' %}?{% if search %}search={{ search|urlencode }}&{% endif %}{% if denomination_filter %}denomination={{ denomination_filter }}&{% endif %}{% if location_filter %}location={{ location_filter }}&{% endif %}{% if county_filter %}county={{ county_filter|urlencode }}&{% endif %}{% if place_filter %}place={{ place_filter|urlencode }}&{% endif %}{% if urban_rural %}urban_rural={{ urban_rural }}&{% endif %}{% if has_membership %}has_membership={{ has_membership }}{% endif %}"
+                               class="ml-1 hover:text-red-700" title="Remove filter">&times;</a>
+                        </span>
+                    {% endif %}
+                    {% if denomination_filter %}
+                        <span class="badge badge-amber inline-flex items-center gap-1">
+                            Denomination
+                            <a href="{% url 'census_browser' %}?{% if search %}search={{ search|urlencode }}&{% endif %}{% if family_filter %}family={{ family_filter|urlencode }}&{% endif %}{% if location_filter %}location={{ location_filter }}&{% endif %}{% if county_filter %}county={{ county_filter|urlencode }}&{% endif %}{% if place_filter %}place={{ place_filter|urlencode }}&{% endif %}{% if urban_rural %}urban_rural={{ urban_rural }}&{% endif %}{% if has_membership %}has_membership={{ has_membership }}{% endif %}"
+                               class="ml-1 hover:text-red-700" title="Remove filter">&times;</a>
+                        </span>
+                    {% endif %}
+                    {% if location_filter %}
+                        <span class="badge badge-amber inline-flex items-center gap-1">
+                            State: {{ current_state.name|default:location_filter }}
+                            <a href="{% url 'census_browser' %}?{% if search %}search={{ search|urlencode }}&{% endif %}{% if family_filter %}family={{ family_filter|urlencode }}&{% endif %}{% if denomination_filter %}denomination={{ denomination_filter }}&{% endif %}{% if urban_rural %}urban_rural={{ urban_rural }}&{% endif %}{% if has_membership %}has_membership={{ has_membership }}{% endif %}"
+                               class="ml-1 hover:text-red-700" title="Remove filter">&times;</a>
+                        </span>
+                    {% endif %}
+                    {% if county_filter %}
+                        <span class="badge badge-amber inline-flex items-center gap-1">
+                            County: {{ county_filter }}
+                            <a href="{% url 'census_browser' %}?{% if search %}search={{ search|urlencode }}&{% endif %}{% if family_filter %}family={{ family_filter|urlencode }}&{% endif %}{% if denomination_filter %}denomination={{ denomination_filter }}&{% endif %}{% if location_filter %}location={{ location_filter }}&{% endif %}{% if place_filter %}place={{ place_filter|urlencode }}&{% endif %}{% if urban_rural %}urban_rural={{ urban_rural }}&{% endif %}{% if has_membership %}has_membership={{ has_membership }}{% endif %}"
+                               class="ml-1 hover:text-red-700" title="Remove filter">&times;</a>
+                        </span>
+                    {% endif %}
+                    {% if place_filter %}
+                        <span class="badge badge-amber inline-flex items-center gap-1">
+                            Place: {{ place_filter }}
+                            <a href="{% url 'census_browser' %}?{% if search %}search={{ search|urlencode }}&{% endif %}{% if family_filter %}family={{ family_filter|urlencode }}&{% endif %}{% if denomination_filter %}denomination={{ denomination_filter }}&{% endif %}{% if location_filter %}location={{ location_filter }}&{% endif %}{% if county_filter %}county={{ county_filter|urlencode }}&{% endif %}{% if urban_rural %}urban_rural={{ urban_rural }}&{% endif %}{% if has_membership %}has_membership={{ has_membership }}{% endif %}"
+                               class="ml-1 hover:text-red-700" title="Remove filter">&times;</a>
+                        </span>
+                    {% endif %}
+                    {% if urban_rural %}
+                        <span class="badge badge-amber inline-flex items-center gap-1">
+                            {{ urban_rural|title }}
+                            <a href="{% url 'census_browser' %}?{% if search %}search={{ search|urlencode }}&{% endif %}{% if family_filter %}family={{ family_filter|urlencode }}&{% endif %}{% if denomination_filter %}denomination={{ denomination_filter }}&{% endif %}{% if location_filter %}location={{ location_filter }}&{% endif %}{% if county_filter %}county={{ county_filter|urlencode }}&{% endif %}{% if place_filter %}place={{ place_filter|urlencode }}&{% endif %}{% if has_membership %}has_membership={{ has_membership }}{% endif %}"
+                               class="ml-1 hover:text-red-700" title="Remove filter">&times;</a>
+                        </span>
                     {% endif %}
                 </div>
             </div>

--- a/templates/census/detail.html
+++ b/templates/census/detail.html
@@ -286,13 +286,13 @@
                                                         </a>
                                                     </td>
                                                 </tr>
-                                                {% if census_record.schedule_denomination.family_census %}
+                                                {% if census_record.schedule_denomination.family_relec %}
                                                     <tr>
-                                                        <th>Census Family</th>
+                                                        <th>Denomination Family</th>
                                                         <td>
-                                                            <a href="{% url 'census_browser' %}?family_census={{ census_record.schedule_denomination.family_census|urlencode }}"
+                                                            <a href="{% url 'census_browser' %}?family={{ census_record.schedule_denomination.family_relec|urlencode }}"
                                                                class="text-religious-primary hover:underline">
-                                                                {{ census_record.schedule_denomination.family_census }}
+                                                                {{ census_record.schedule_denomination.family_relec }}
                                                             </a>
                                                         </td>
                                                     </tr>


### PR DESCRIPTION
## Summary
- **Fix N+1 queries** in `DenominationViewSet.families()` and `ReligiousBodyViewSet.denomination_families()` — replace per-family COUNT loops with single aggregation queries using `.values().annotate()` and conditional `Count(filter=Q())`
- **Add caching** to previously uncached public views: `map_view`, `demographics_map_view`, `api_documentation_view`, `BlogListView`, `BlogDetailView`, `VisualizationListView`, `VisualizationDetailView` (all 15 min)
- **Consolidate visualization URLs** under `/visualizations/` prefix — moved from scattered `/census/map/`, `/census/viz/`, `/census/demographics-map/` paths
- **Fix browser filter state**: denomination dropdown auto-selects its family when linked from Browse by Denomination page; dropdown enables correctly when denomination is pre-selected
- **Detail page**: "Census Family" link now uses `family_relec` (matches browser dropdown) instead of `family_census`
- **Filter pills**: replace generic "Filtered" badge with individual pills showing each active filter with × to remove