### PR TITLE
Add health endpoint and re-enable debug toolbar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,17 +51,9 @@ Setup for new deployments:
 
 ---
 
-## Daphne/ASGI Async Compatibility
+## Django Debug Toolbar
 
-### Issue
-Django 5.1 running via Daphne in async (ASGI) mode causes `SynchronousOnlyOperation` errors with django-debug-toolbar.
-
-### Solution
-**Disabled django-debug-toolbar:**
-- Commented out in `config/settings.py`: `INSTALLED_APPS += ["debug_toolbar"]` and the middleware line
-- `config/urls.py` conditionally includes toolbar only if it's in `INSTALLED_APPS`
-
-**To re-enable later:** Wait for django-debug-toolbar to release Daphne/ASGI-compatible version, then uncomment the lines in `settings.py`.
+Enabled conditionally when `DEBUG=True` in `config/settings.py`. The toolbar and its middleware are only added to `INSTALLED_APPS` and `MIDDLEWARE` in debug mode. URLs are registered at `__debug__/` in `config/urls.py`, also gated on `DEBUG`.
 
 ---
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -91,6 +91,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "religious_ecologies.middleware.HealthCheckMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -108,10 +109,10 @@ X_FRAME_OPTIONS = "SAMEORIGIN"
 # ------------------------------------------------------------------------------
 # django-debug-toolbar
 # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#prerequisites
-# Temporarily disabled due to Django 6.0 async compatibility issues
-# INSTALLED_APPS += ["debug_toolbar"]  # noqa: F405
-# https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#middleware
-# MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]  # noqa: F405
+if DEBUG:
+    INSTALLED_APPS += ["debug_toolbar"]
+    # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#middleware
+    MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]
 # https://django-debug-toolbar.readthedocs.io/en/latest/configuration.html#debug-toolbar-config
 DEBUG_TOOLBAR_CONFIG = {
     "DISABLE_PANELS": ["debug_toolbar.panels.redirects.RedirectsPanel"],

--- a/config/urls.py
+++ b/config/urls.py
@@ -49,3 +49,6 @@ urlpatterns = [
 if settings.DEBUG:
     # Serve static files in development
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+
+    # django-debug-toolbar
+    urlpatterns = [path("__debug__/", include("debug_toolbar.urls"))] + urlpatterns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "pytest-django>=4.9.0",
     "pylint-django>=2.6.1",
     "factory-boy>=3.3.0",
+    "django-debug-toolbar>=6.3.0",
 ]
 
 [tool.pytest.ini_options]

--- a/religious_ecologies/middleware.py
+++ b/religious_ecologies/middleware.py
@@ -1,0 +1,19 @@
+from django.db import connection
+from django.http import JsonResponse
+
+
+class HealthCheckMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.path == "/health/":
+            try:
+                connection.ensure_connection()
+                return JsonResponse({"status": "ok", "code": 200})
+            except Exception:
+                return JsonResponse(
+                    {"status": "error", "code": 503, "detail": "database unavailable"},
+                    status=503,
+                )
+        return self.get_response(request)

--- a/uv.lock
+++ b/uv.lock
@@ -449,6 +449,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-debug-toolbar"
+version = "6.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "sqlparse" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/ea/b62673424dd72d2dbf5adf4145281a421d5792f47380d9bc8e3b11e1a769/django_debug_toolbar-6.3.0.tar.gz", hash = "sha256:f830a86fe02e17f625a22cfbed24a5bd1500762e201ec959c50efb0f9327282b", size = 334079, upload-time = "2026-04-02T16:07:01.385Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/9e/d8c3c845f4b5ccac7377c19f4049e7e00c6f121846a81f69a497b45734df/django_debug_toolbar-6.3.0-py3-none-any.whl", hash = "sha256:a199ce3d0f884739a9096835ad417479fede05f3b3c4824bc8b354721ba8f629", size = 298304, upload-time = "2026-04-02T16:06:59.617Z" },
+]
+
+[[package]]
 name = "django-environ"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1218,6 +1231,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "black" },
+    { name = "django-debug-toolbar" },
     { name = "djhtml" },
     { name = "factory-boy" },
     { name = "pre-commit" },
@@ -1255,6 +1269,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "black", specifier = ">=24.10.0" },
+    { name = "django-debug-toolbar", specifier = ">=6.3.0" },
     { name = "djhtml", specifier = ">=3.0.7" },
     { name = "factory-boy", specifier = ">=3.3.0" },
     { name = "pre-commit", specifier = ">=4.0.1" },


### PR DESCRIPTION
## Summary
- Re-enable `django-debug-toolbar` conditionally when `DEBUG=True` — async/ASGI support landed in 5.x (GSoC 2024), resolving the Daphne `SynchronousOnlyOperation` blocker (closes #110)
- Add `/health/` endpoint via middleware for Docker container monitoring — checks DB connectivity, returns JSON, placed first in middleware stack so it responds even if downstream middleware is broken (closes #109)
